### PR TITLE
🔨 [PIPE-592] Remove "Rust" from all rust helpers

### DIFF
--- a/clients/bendini/bendini.nix
+++ b/clients/bendini/bendini.nix
@@ -1,5 +1,5 @@
 { pkgs, base }:
-base.languages.rust.mkRustClient {
+base.languages.rust.mkClient {
   name = "bendini";
   src = ./.;
 }

--- a/clients/lomax/lomax.nix
+++ b/clients/lomax/lomax.nix
@@ -1,5 +1,5 @@
 { pkgs, base, avery }:
-base.languages.rust.mkRustClient {
+base.languages.rust.mkClient {
   name = "lomax";
   src = ./.;
 

--- a/functions/start-maya/start-maya.nix
+++ b/functions/start-maya/start-maya.nix
@@ -1,5 +1,5 @@
 { pkgs, base, rustGbkUtils }:
-base.languages.rust.mkRustFunction {
+base.languages.rust.mkFunction {
   manifest = ./function.toml;
   name = "start-maya";
   src = ./.;

--- a/nedryland/function.nix
+++ b/nedryland/function.nix
@@ -42,9 +42,9 @@ base.extend.mkExtension {
   languages = base.extend.mkLanguageHelper {
     language = "rust";
     functions = {
-      mkRustFunction = attrs@{ name, src, manifest, buildInputs ? [], extensions ? [], targets ? [], ... }:
+      mkFunction = attrs@{ name, src, manifest, buildInputs ? [], extensions ? [], targets ? [], ... }:
         let
-          component = base.languages.rust.mkRustComponent (
+          component = base.languages.rust.mkComponent (
             attrs // {
               targets = targets ++ [ "wasm32-wasi" ];
               hasTests = false;

--- a/project.nix
+++ b/project.nix
@@ -9,7 +9,7 @@ let
       builtins.fetchGit {
         name = "nedryland";
         url = "git@github.com:goodbyekansas/nedryland.git";
-        rev = "d68cfd1a5387279bc32610721cfaec2c62090cfb";
+        rev = "aa438e5501789c1ba969d285a2b1be339a62cbe9";
       }
   );
 

--- a/services/avery/avery.nix
+++ b/services/avery/avery.nix
@@ -1,6 +1,6 @@
 { pkgs, base, inputFunctions }:
 with pkgs;
-base.languages.rust.mkRustService {
+base.languages.rust.mkService {
   name = "avery";
   src = ./.;
 

--- a/utils/rust/gbk/gbk.nix
+++ b/utils/rust/gbk/gbk.nix
@@ -1,4 +1,4 @@
-{ base, pkgs }: base.languages.rust.mkRustUtility {
+{ base, pkgs }: base.languages.rust.mkUtility {
   name = "gbk";
   src = ./.;
   hasTests = false;


### PR DESCRIPTION
Support latest change in Nedryland that removed the "Rust" prefix.
Follow that and do the same for `mkRustFunction`.