### PR TITLE
[PIPE-587] ✨ Add registry filtering

### DIFF
--- a/clients/bendini/src/main.rs
+++ b/clients/bendini/src/main.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+//#![allow(warnings)]
 
 // module declarations
 pub mod proto {
@@ -23,7 +24,8 @@ use uuid::Uuid;
 use proto::functions_client::FunctionsClient;
 use proto::{
     ArgumentType, ExecuteRequest, ExecuteResponse, Function, FunctionArgument, FunctionId,
-    FunctionInput, FunctionOutput, GetLatestVersionRequest, ListRequest,
+    FunctionInput, FunctionOutput, GetLatestVersionRequest, ListRequest, OrderingDirection,
+    OrderingKey, VersionRequirement,
 };
 
 /// Bendini is a command line client to Avery, the function executor service of the GBK pipeline
@@ -204,8 +206,12 @@ fn main() -> Result<(), u32> {
                 let list_request = ListRequest {
                     name_filter: String::new(),
                     tags_filter: HashMap::new(),
-                    limit: 0,
+                    exact_name_match: false,
+                    order_by: OrderingKey::Name as i32,
+                    order_direction: OrderingDirection::Ascending as i32,
+                    version_requirement: None,
                     offset: 0,
+                    limit: 25,
                 };
 
                 let list_response = basic_rt
@@ -234,7 +240,11 @@ fn main() -> Result<(), u32> {
                 let list_request = ListRequest {
                     name_filter: String::new(),
                     tags_filter: HashMap::new(),
-                    limit: 0,
+                    exact_name_match: false,
+                    order_by: OrderingKey::Name as i32,
+                    order_direction: OrderingDirection::Ascending as i32,
+                    version_requirement: None,
+                    limit: 25,
                     offset: 0,
                 };
 
@@ -273,8 +283,9 @@ fn main() -> Result<(), u32> {
                         .block_on(client.get_latest_version(Request::new(
                             GetLatestVersionRequest {
                                 name: function_name.to_owned(),
-                                version_requirement:
-                                    function_version.unwrap_or_else(|| "*").to_owned(),
+                                version_requirement: Some(VersionRequirement {
+                                    expression: function_version.unwrap_or_else(|| "*").to_owned(),
+                                }),
                             },
                         )))
                         .map_err(|e| {

--- a/clients/lomax/src/main.rs
+++ b/clients/lomax/src/main.rs
@@ -24,7 +24,7 @@ use tonic::Request;
 use proto::functions_registry_client::FunctionsRegistryClient;
 use proto::{
     ArgumentType, ExecutionEnvironment, Function, FunctionDescriptor, FunctionId, FunctionInput,
-    FunctionOutput, ListRequest, RegisterRequest,
+    FunctionOutput, ListRequest, OrderingDirection, OrderingKey, RegisterRequest,
 };
 
 // arguments
@@ -261,8 +261,12 @@ fn main() -> Result<(), u32> {
             let list_request = ListRequest {
                 name_filter: String::new(),
                 tags_filter: HashMap::new(),
-                limit: 0,
+                limit: 25,
                 offset: 0,
+                exact_name_match: false,
+                order_direction: OrderingDirection::Ascending as i32,
+                order_by: OrderingKey::Name as i32,
+                version_requirement: None,
             };
 
             let list_response = basic_rt

--- a/protocols/functions.proto
+++ b/protocols/functions.proto
@@ -8,9 +8,6 @@ service FunctionsRegistry {
   rpc List (ListRequest) returns (RegistryListResponse);
   rpc Get (FunctionId) returns (FunctionDescriptor);
   rpc GetLatestVersion (GetLatestVersionRequest) returns (FunctionDescriptor);
-
-  // TODO: ListVersions must be removed and combined with List instead.
-  rpc ListVersions (ListVersionsRequest) returns (RegistryListResponse);
   rpc Register (RegisterRequest) returns (FunctionId);
 }
 
@@ -21,26 +18,27 @@ service Functions {
   rpc Execute (ExecuteRequest) returns (ExecuteResponse);
 }
 
+message VersionRequirement {
+  string expression = 1;
+}
+
+enum OrderingDirection { ASCENDING = 0; DESCENDING = 1; }
+enum OrderingKey { NAME = 0; }
+
 message ListRequest {
   string name_filter = 1;
   map<string, string> tags_filter = 2;
   uint32 offset = 3;
   uint32 limit = 4;
-}
-
-enum Ordering { ASCENDING = 0; DESCENDING = 1; }
-
-message ListVersionsRequest {
-  string name = 1;
-  string version_requirement = 2;
-  uint32 offset = 3;
-  uint32 limit = 4;
-  Ordering ordering = 5;
+  bool exact_name_match = 5;
+  VersionRequirement version_requirement = 6;
+  OrderingDirection order_direction = 7;
+  OrderingKey order_by = 8;
 }
 
 message GetLatestVersionRequest {
   string name = 1;
-  string version_requirement = 2;
+  VersionRequirement version_requirement = 2;
 }
 
 message ListResponse {

--- a/services/avery/tests/functions.rs
+++ b/services/avery/tests/functions.rs
@@ -9,7 +9,7 @@ use avery::{
         functions_registry_server::FunctionsRegistry,
         functions_server::Functions as FunctionsTrait, ArgumentType, ExecuteRequest,
         ExecutionEnvironment, FunctionArgument, FunctionId, FunctionInput, FunctionOutput,
-        ListRequest, RegisterRequest,
+        ListRequest, OrderingDirection, OrderingKey, RegisterRequest,
     },
     registry::FunctionsRegistryService,
     FunctionsService,
@@ -109,6 +109,10 @@ macro_rules! first_function {
             tags_filter: HashMap::new(),
             offset: 0,
             limit: 100,
+            exact_name_match: false,
+            version_requirement: None,
+            order_direction: OrderingDirection::Descending as i32,
+            order_by: OrderingKey::Name as i32,
         })))
         .unwrap()
         .into_inner()
@@ -127,6 +131,10 @@ fn test_list() {
         tags_filter: HashMap::new(),
         offset: 0,
         limit: 100,
+        exact_name_match: false,
+        version_requirement: None,
+        order_direction: OrderingDirection::Descending as i32,
+        order_by: OrderingKey::Name as i32,
     })));
 
     assert!(r.is_ok());
@@ -139,6 +147,10 @@ fn test_list() {
         tags_filter: HashMap::new(),
         offset: 0,
         limit: 100,
+        exact_name_match: false,
+        version_requirement: None,
+        order_direction: OrderingDirection::Descending as i32,
+        order_by: OrderingKey::Name as i32,
     })));
     assert!(r.is_ok());
     let fns = r.unwrap().into_inner();


### PR DESCRIPTION
We can now filter on name, version, and tags. We can order by name(then version). We can order ascending or descending.