### PR TITLE
🔨 Remove `GetLatestVersion`

### DIFF
--- a/clients/bendini/build.rs
+++ b/clients/bendini/build.rs
@@ -3,6 +3,12 @@ use std::{env, path::Path};
 fn main() {
     let proto_env = env::var("PROTOBUF_DEFINITIONS_LOCATION").unwrap();
     let proto_path = Path::new(&proto_env);
+
+    println!(
+        "cargo:rerun-if-changed={}/functions.proto",
+        proto_path.display()
+    );
+
     tonic_build::configure()
         .build_server(false)
         .compile(

--- a/protocols/functions.proto
+++ b/protocols/functions.proto
@@ -7,14 +7,12 @@ package functions;
 service FunctionsRegistry {
   rpc List (ListRequest) returns (RegistryListResponse);
   rpc Get (FunctionId) returns (FunctionDescriptor);
-  rpc GetLatestVersion (GetLatestVersionRequest) returns (FunctionDescriptor);
   rpc Register (RegisterRequest) returns (FunctionId);
 }
 
 service Functions {
   rpc List (ListRequest) returns (ListResponse);
   rpc Get (FunctionId) returns (Function);
-  rpc GetLatestVersion (GetLatestVersionRequest) returns (Function);
   rpc Execute (ExecuteRequest) returns (ExecuteResponse);
 }
 

--- a/services/avery/src/lib.rs
+++ b/services/avery/src/lib.rs
@@ -21,7 +21,7 @@ use proto::functions_registry_server::FunctionsRegistry;
 use proto::functions_server::Functions as FunctionsServiceTrait;
 use proto::{
     execute_response::Result as ProtoResult, ExecuteRequest, ExecuteResponse, Function, FunctionId,
-    GetLatestVersionRequest, ListRequest, ListResponse,
+    ListRequest, ListResponse,
 };
 
 // define the FunctionsService struct
@@ -118,26 +118,6 @@ impl FunctionsServiceTrait for FunctionsService {
                 "Function descriptor did not contain any function.",
             )
         })
-    }
-
-    async fn get_latest_version(
-        &self,
-        request: tonic::Request<GetLatestVersionRequest>,
-    ) -> Result<tonic::Response<Function>, tonic::Status> {
-        let function_descriptor = self
-            .functions_register
-            .get_latest_version(tonic::Request::new(request.into_inner()))
-            .await?
-            .into_inner();
-        function_descriptor
-            .function
-            .map(tonic::Response::new)
-            .ok_or_else(|| {
-                tonic::Status::new(
-                    tonic::Code::Internal,
-                    "Function descriptor did not contain any function.",
-                )
-            })
     }
 
     async fn execute(

--- a/services/avery/tests/registry.rs
+++ b/services/avery/tests/registry.rs
@@ -4,8 +4,7 @@ use futures;
 
 use avery::proto::{
     functions_registry_server::FunctionsRegistry, ArgumentType, ExecutionEnvironment, FunctionId,
-    FunctionInput, FunctionOutput, GetLatestVersionRequest, ListRequest, OrderingDirection,
-    OrderingKey, RegisterRequest, VersionRequirement,
+    FunctionInput, FunctionOutput, ListRequest, OrderingDirection, OrderingKey, RegisterRequest,
 };
 use avery::registry::FunctionsRegistryService;
 
@@ -496,45 +495,6 @@ fn test_register_function() {
         })
     )));
     assert!(register_result.is_ok());
-}
-
-#[test]
-fn test_list_versions() {
-    let fr = registry!();
-
-    futures::executor::block_on(fr.register(register_request_with_version!("my-name", "1.2.3")))
-        .unwrap();
-    futures::executor::block_on(fr.register(register_request_with_version!("my-name", "2.0.3")))
-        .unwrap();
-    futures::executor::block_on(fr.register(register_request_with_version!("my-name", "8.1.4")))
-        .unwrap();
-
-    // since these are prereleases, they will only match exact version requirements
-    let latest_result = futures::executor::block_on(fr.get_latest_version(tonic::Request::new(
-        GetLatestVersionRequest {
-            name: "my-name".to_owned(),
-            version_requirement: Some(VersionRequirement {
-                expression: "2.0.3-dev".to_owned(),
-            }),
-        },
-    )));
-
-    assert!(latest_result.is_ok());
-
-    let latest_result = futures::executor::block_on(fr.get_latest_version(tonic::Request::new(
-        GetLatestVersionRequest {
-            name: "my-name".to_owned(),
-            version_requirement: Some(VersionRequirement {
-                expression: "2.0.3".to_owned(),
-            }),
-        },
-    )));
-
-    assert!(latest_result.is_err());
-    assert!(matches!(
-        latest_result.unwrap_err().code(),
-        tonic::Code::NotFound
-    ));
 }
 
 #[test]


### PR DESCRIPTION
Remove `GetLatestVersion` both from Functions and Registry. It is not
significantly different from a List request and therefore list should be
used instead.