### PR TITLE
⚡️ Set nocapture for tests in wasi

### DIFF
--- a/nedryland/function.nix
+++ b/nedryland/function.nix
@@ -91,6 +91,7 @@ base.extend.mkExtension {
                   cp target/wasm32-wasi/release/*.wasm $out/bin
                 '';
                 CARGO_TARGET_WASM32_WASI_RUNNER = "wasmer";
+                RUST_TEST_NOCAPTURE = 1;
                 cargoAlias = ''
                   cargo()
                   {


### PR DESCRIPTION
This is needed since wasi is a `panic=abort` platform. More details
[here](https://bytecodealliance.github.io/cargo-wasi/testing.html)