### PR TITLE
👕 Clippy was very sad

### DIFF
--- a/utils/rust/gbk/gbk.nix
+++ b/utils/rust/gbk/gbk.nix
@@ -6,6 +6,6 @@ base.languages.rust.mkUtility {
   targets = [ "wasm32-wasi" ];
   useNightly = "2020-05-01";
   rustDependencies = [ protocols ];
-  testFeatures = [ "net" ];
-  buildFeatures = [ "net" "mock" ];
+  testFeatures = [ "net" "mock" ];
+  buildFeatures = [ "net" ];
 }


### PR DESCRIPTION
Some optional features were not enabled when running clippy which led to
errors in crates that depended on gbk-lib.