### PR TITLE
✨ [PIPE-982] Add support for optional attachments

### DIFF
--- a/nedryland/copy_attachments.py
+++ b/nedryland/copy_attachments.py
@@ -1,0 +1,72 @@
+import argparse
+import json
+import os
+import os.path
+import shutil
+import sys
+
+
+def copyFileToOutput(path: str, target_filename: str) -> None:
+    os.makedirs(os.path.dirname(target_filename), exist_ok=True)
+    shutil.copy(path, target_filename)
+
+
+def read_infile(path: str) -> dict:
+    with open(args.infile) as json_file:
+        return json.load(json_file)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Copy attachments to a folder")
+    parser.add_argument("outputfolder", help="Folder to put attachments in")
+    parser.add_argument("infile", help="Input json file")
+    parser.add_argument("outfile", help="Output json file")
+
+    parser.add_argument("--quiet", action="store_true", default=False)
+
+    args = parser.parse_args()
+
+    json_data = {}
+    try:
+        json_data = read_infile(args.infile)
+    except Exception as e:
+        print(f"Failed to read JSON data from {args.infile}: {e}")
+        sys.exit(1)
+
+    json_data = json_data["manifest"]
+    output_data = json_data.copy()
+
+    # only keep attachments that are either required or exists
+    required_or_existing_attachments = {
+        n: a
+        for n, a in json_data.get("attachments").items()
+        if a.get("required", True) or os.path.exists(a["path"])
+    }
+
+    for name, attachment in required_or_existing_attachments.items():
+        target = os.path.join(args.outputfolder, attachment["path"])
+        if not os.path.exists(attachment["path"]):
+            print(
+                f"Attachment {name} is required but does not exist at {attachment['path']}, exiting..."
+            )
+            sys.exit(1)
+
+        if not args.quiet:
+            print(f"Copying attachment {name} at {attachment['path']} to {target}")
+
+        try:
+            copyFileToOutput(attachment["path"], target)
+        except Exception as e:
+            print(
+                "Failed to copy attachment {name} at {attachment['path']} to {target}: {e}"
+            )
+            sys.exit(1)
+
+    output_data["attachments"] = required_or_existing_attachments
+    output_data = {"manifest": output_data}
+
+    with open(args.outfile, "w") as outfile:
+        json.dump(output_data, outfile)
+
+    print(f"JSON written to {args.outfile}")

--- a/nedryland/function.nix
+++ b/nedryland/function.nix
@@ -12,16 +12,19 @@ let
       '';
     };
 
-  # TODO investigate if code should be different from attachment, i.e: code vs manifest.attachments
   mkFunction = attrs@{ name, package, manifest, code, ... }:
     let
       manifestGenerator = pkgs.callPackage ./manifest.nix {
-        inherit name code manifest;
-        attachments = manifest.attachments or { };
+        inherit name;
+        manifest = manifest // {
+          code = {
+            path = code;
+          };
+        };
       };
 
       packageWithManifest = package.overrideAttrs (oldAttrs: {
-        buildInputs = oldAttrs.buildInputs ++ [ manifestGenerator ];
+        nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [ manifestGenerator ];
       });
     in
     base.mkComponent (

--- a/nedryland/generate_checksums.py
+++ b/nedryland/generate_checksums.py
@@ -1,0 +1,74 @@
+import argparse
+import hashlib
+import json
+import os.path
+import sys
+
+
+def generateSha256Checksum(attachment: dict) -> str:
+    sha256 = hashlib.sha256()
+    if os.path.exists(attachment["path"]):
+        with open(attachment["path"], "rb") as f:
+            for byte_block in iter(lambda: f.read(4096), b""):
+                sha256.update(byte_block)
+
+    return sha256.hexdigest()
+
+
+def generateSha512Checksum(attachment: dict) -> str:
+    sha512 = hashlib.sha512()
+    if os.path.exists(attachment["path"]):
+        with open(attachment["path"], "rb") as f:
+            for byte_block in iter(lambda: f.read(4096), b""):
+                sha512.update(byte_block)
+
+    return sha512.hexdigest()
+
+
+def generateChecksums(data: dict, sha512: bool) -> dict:
+    dataWithChecksums = data.copy()
+    for name, attachment in data.items():
+        dataWithChecksums[name].update(
+            {"checksums": {"sha256": generateSha256Checksum(attachment)}}
+        )
+
+        if sha512:
+            dataWithChecksums[name]["checksums"][
+                "sha512"
+            ] = generateSha512Checksum(attachment)
+
+    return dataWithChecksums
+
+
+def read_infile(path: str) -> dict:
+    with open(args.infile) as json_file:
+        return json.load(json_file)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Generate checksums for attachments")
+    parser.add_argument("infile", help="Input json file")
+    parser.add_argument("outfile", help="Output json file")
+    parser.add_argument("--sha512", action="store_true", default=False)
+
+    args = parser.parse_args()
+
+    json_data = {}
+    try:
+        json_data = read_infile(args.infile)
+    except Exception as e:
+        print(f"Failed to read JSON data from {args.infile}: {e}")
+        sys.exit(1)
+
+    json_data = json_data["manifest"]
+    output = json_data.copy()
+    output["attachments"] = generateChecksums(json_data.get("attachments", {}), args.sha512)
+    output["code"] = generateChecksums({"code": json_data["code"]}, args.sha512)["code"]
+
+    output = {"manifest": output}
+
+    with open(args.outfile, "w") as outfile:
+        json.dump(output, outfile)
+
+    print(f"JSON written to {args.outfile}")

--- a/nedryland/manifest-template.jinja.toml
+++ b/nedryland/manifest-template.jinja.toml
@@ -1,0 +1,31 @@
+name = "{{ manifest.name }}"
+version = "{{ manifest.version }}"
+
+[execution-environment]
+entrypoint = "{{ manifest['execution-environment'].entrypoint }}"
+type = "{{ manifest['execution-environment'].type }}"
+
+{% if manifest.attachments -%}
+[attachments]
+
+{%- for name, attachment in manifest.attachments.items() %}
+
+[attachments.{{name}}]
+path = "attachments/{{ attachment.path }}"
+
+[attachments.{{name}}.checksums]
+{%- for k, v in attachment.checksums.items() %}
+{{ k }} = "{{ v }}"
+{%- endfor -%}
+
+{% endfor -%}
+
+{%- endif %}
+
+[code]
+path = "{{manifest.code.path}}"
+
+[code.checksums]
+{%- for k, v in manifest.code.checksums.items() %}
+{{ k }} = "{{ v }}"
+{%- endfor -%}

--- a/project.nix
+++ b/project.nix
@@ -10,7 +10,7 @@ let
         builtins.fetchGit {
           name = "nedryland";
           url = "git@github.com:goodbyekansas/nedryland.git";
-          ref = "refs/tags/0.4.1";
+          ref = "refs/tags/0.5.0";
         }
     );
 


### PR DESCRIPTION
Use jinja templating for generating manifest since `substituteAll` can
no longer satisfy our needs for generating the manifest file. Switching
to using a jinja template instead.