### PR TITLE
✨ [PIPE-999] Pass shellInputs and shellHook in rust function

### DIFF
--- a/nedryland/function.nix
+++ b/nedryland/function.nix
@@ -58,12 +58,15 @@ base.extend.mkExtension {
         , extraChecks ? ""
         , buildFeatures ? [ ]
         , testFeatures ? [ ]
+        , ...
         }:
         let
           package = base.languages.rust.mkPackage {
             inherit src name rustDependencies useNightly buildInputs extraChecks buildFeatures testFeatures;
             targets = targets ++ [ "wasm32-wasi" ];
             defaultTarget = "wasm32-wasi";
+            shellInputs = attrs.shellInputs or [ ];
+            shellHook = attrs.shellHook or "";
           };
 
           newPackage = package.overrideAttrs (

--- a/project.nix
+++ b/project.nix
@@ -10,7 +10,7 @@ let
         builtins.fetchGit {
           name = "nedryland";
           url = "git@github.com:goodbyekansas/nedryland.git";
-          rev = "4440e6b115869c4caf5627ae48a6f52d14b2a7e4";
+          rev = "1dc8d12052ea48d0faaaf679381e5b46b6d7551a";
         }
     );
 


### PR DESCRIPTION
This makes it possible for rust functions to add shell inputs and hook
steps.