### PR TITLE
✨ [PIPE-798] Add host folder mappings

### DIFF
--- a/clients/lomax/src/formatting.rs
+++ b/clients/lomax/src/formatting.rs
@@ -1,8 +1,8 @@
 use std::fmt::{self, Display};
 
 use gbk_protocols::functions::{
-    ArgumentType, ExecutionEnvironment, Function, FunctionDescriptor, FunctionId, FunctionInput,
-    FunctionOutput,
+    ArgumentType, ExecutionEnvironment, FunctionDescriptor, FunctionHostFolderMount, FunctionId,
+    FunctionInput, FunctionOutput,
 };
 
 pub struct Displayer<'a, T> {
@@ -72,6 +72,17 @@ impl Display for Displayer<'_, FunctionDescriptor> {
                 }
                 write!(f, "{}codeUrl: ", t)?;
 
+                if self.host_folder_mounts.is_empty() {
+                    writeln!(f, "\tmounts: [n/a]")?;
+                } else {
+                    writeln!(f, "\tmounts:")?;
+                    self.host_folder_mounts
+                        .clone()
+                        .into_iter()
+                        .map(|mount| writeln!(f, "{}{}", t2, mount.display()))
+                        .collect::<fmt::Result>()?;
+                }
+
                 writeln!(
                     f,
                     "{}",
@@ -117,42 +128,19 @@ impl Display for Displayer<'_, FunctionDescriptor> {
     }
 }
 
-impl Display for Displayer<'_, Function> {
+impl Display for Displayer<'_, FunctionHostFolderMount> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let na = "n/a".to_string();
-        let id_str = self.id.clone().unwrap_or(FunctionId { value: na }).value;
-        writeln!(f, "\t{}", self.name)?;
-        writeln!(f, "\tid:      {}", id_str)?;
-        if self.inputs.is_empty() {
-            writeln!(f, "\tinputs:  n/a")?;
-        } else {
-            writeln!(f, "\tinputs:")?;
-            self.inputs
-                .clone()
-                .into_iter()
-                .map(|i| writeln!(f, "\t\t {}", i.display()))
-                .collect::<fmt::Result>()?;
-        }
-        if self.outputs.is_empty() {
-            writeln!(f, "\toutputs: n/a")?;
-        } else {
-            writeln!(f, "\toutputs:")?;
-            self.outputs
-                .clone()
-                .into_iter()
-                .map(|i| writeln!(f, "\t\t {}", i.display()))
-                .collect::<fmt::Result>()?;
-        }
-        if self.metadata.is_empty() {
-            writeln!(f, "\tmetadata:    n/a")
-        } else {
-            writeln!(f, "\tmetadata:")?;
-            self.metadata
-                .clone()
-                .iter()
-                .map(|(x, y)| writeln!(f, "\t\t {}:{}", x, y))
-                .collect()
-        }
+        writeln!(
+            f,
+            "[{}] {}:{}",
+            if self.required {
+                "required"
+            } else {
+                "optional"
+            },
+            self.target_folder_path,
+            self.host_folder_path
+        )
     }
 }
 

--- a/nedryland/manifest-template.jinja.toml
+++ b/nedryland/manifest-template.jinja.toml
@@ -45,3 +45,16 @@ path = "{{manifest.code.path}}"
 {%- for k, v in manifest.code.checksums.items() %}
 {{ k }} = "{{ v }}"
 {%- endfor -%}
+
+{%- if manifest.mounts %}
+
+[mounts]
+
+{%- for name, mount in manifest.mounts.items() %}
+
+[mounts."{{name}}"]
+hostpath = "{{ mount.hostpath }}"
+required = {{ mount.required }}
+{%- endfor %}
+
+{% endif %}

--- a/nedryland/manifest.nix
+++ b/nedryland/manifest.nix
@@ -13,18 +13,29 @@ let
     )
     attachments;
 
-  manifestWithNormalizedAttachments = {
+  normalizeMounts = mounts: pkgs.lib.mapAttrs
+    (
+      mountName: mountPathOrData:
+        {
+          hostpath = if builtins.isString mountPathOrData then mountPathOrData else mountPathOrData.hostPath;
+          required = if builtins.isString mountPathOrData then true else mountPathOrData.required;
+        }
+    )
+    mounts;
+
+  normalizedManifest = {
     # wrap this in a key to be able to
     # use variables with dashes in Jinja later
     manifest = manifest // {
       attachments = normalizeAttachments manifest.attachments or { };
+      mounts = normalizeMounts manifest.mounts or { };
     };
   };
 in
 pkgs.stdenv.mkDerivation {
   name = "${name}-manifest";
   propagatedBuildInputs = [ j2 ];
-  manifestData = builtins.toJSON manifestWithNormalizedAttachments;
+  manifestData = builtins.toJSON normalizedManifest;
   passAsFile = [ "manifestData" ];
 
   # we need the fixupPhase to exist even though

--- a/protocols/functions/functions.proto
+++ b/protocols/functions/functions.proto
@@ -57,21 +57,33 @@ message ExecutionEnvironment {
   repeated FunctionArgument args = 3;
 }
 
+// All info for a function
+// Needs to be enough to execute it
 message FunctionDescriptor {
   ExecutionEnvironment execution_environment = 1;
   FunctionAttachment code = 2;
   Function function = 3;
   repeated FunctionAttachment attachments = 5;
+  repeated FunctionHostFolderMount host_folder_mounts = 6;
 }
 
+// Metadata about a function. I.e. what is needed
+// to reason about it, not execute it
 message Function {
-  // this record is only for discussing metadata of a function not its code
   FunctionId id = 1;
   string name = 2;
   string version = 3;
   map<string, string> metadata = 4;
   repeated FunctionInput inputs = 5;
   repeated FunctionOutput outputs = 6;
+}
+
+// A mount of a host folder to
+// the function domain (e.g. WASI)
+message FunctionHostFolderMount {
+  string host_folder_path = 1;
+  string target_folder_path = 2;
+  bool required_ = 3;
 }
 
 message RegisterRequest {
@@ -83,6 +95,8 @@ message RegisterRequest {
   ExecutionEnvironment execution_environment = 6;
   string version = 7;
   repeated FunctionAttachmentId attachment_ids = 9;
+  repeated FunctionHostFolderMount host_folder_mounts = 10;
+
 }
 
 message FunctionAttachment {

--- a/protocols/rust/test_macros/src/lib.rs
+++ b/protocols/rust/test_macros/src/lib.rs
@@ -103,6 +103,7 @@ macro_rules! register_request {
             inputs: vec![$($input),*],
             outputs: vec![$($output),*],
             attachment_ids: vec![],
+            host_folder_mounts: vec![],
         }
     }};
 
@@ -141,6 +142,7 @@ macro_rules! register_request {
                     id: String::from($attach),
                 }
             ),*],
+            host_folder_mounts: vec![],
         }
     }};
 }

--- a/services/avery/src/executor.rs
+++ b/services/avery/src/executor.rs
@@ -951,6 +951,7 @@ mod tests {
                 }),
                 code: Some(code_file!(s.as_bytes())),
                 attachments: vec![],
+                host_folder_mounts: vec![],
                 function: Some(Function {
                     id: Some(FunctionId {
                         value: "huuuuuus".to_owned(),
@@ -1070,6 +1071,7 @@ mod tests {
                 }),
                 code: Some(code_file!(s.as_bytes())),
                 attachments: vec![],
+                host_folder_mounts: vec![],
                 function: Some(Function {
                     id: Some(FunctionId {
                         value: "pieceee of pie".to_owned(),
@@ -1158,6 +1160,7 @@ mod tests {
                 inputs: vec![],
                 outputs: vec![],
                 attachment_ids: vec![],
+                host_folder_mounts: vec![],
             },
             RegisterRequest {
                 execution_environment: Some(ExecutionEnvironment {
@@ -1172,6 +1175,7 @@ mod tests {
                 inputs: vec![],
                 outputs: vec![],
                 attachment_ids: vec![],
+                host_folder_mounts: vec![],
             },
             RegisterRequest {
                 execution_environment: Some(ExecutionEnvironment {
@@ -1186,6 +1190,7 @@ mod tests {
                 inputs: vec![],
                 outputs: vec![],
                 attachment_ids: vec![],
+                host_folder_mounts: vec![],
             },
         ]
         .into_iter()

--- a/services/avery/src/registry.rs
+++ b/services/avery/src/registry.rs
@@ -277,6 +277,7 @@ impl FunctionsRegistryService {
             execution_environment: Some(f.execution_environment.clone()),
             code,
             attachments,
+            host_folder_mounts: vec![],
         })
     }
 }

--- a/services/avery/tests/functions.rs
+++ b/services/avery/tests/functions.rs
@@ -51,6 +51,7 @@ macro_rules! functions_service_with_functions {
                     args: vec![],
                 }),
                 attachment_ids: vec![],
+                host_folder_mounts: vec![],
             },
             RegisterRequest {
                 name: "say-hello-yourself".to_owned(),
@@ -83,6 +84,7 @@ macro_rules! functions_service_with_functions {
                     args: vec![],
                 }),
                 attachment_ids: vec![],
+                host_folder_mounts: vec![],
             },
         ]
         .iter()


### PR DESCRIPTION
Host folder mappings is a way for the function (in its' manifest) to
express that it wants host folders to be mapped into its' filesystem
sandbox. This makes it possible to do discovery on the file system. Note
that the mounts will be read-only so it is not a giant exploit.