### PR TITLE
✨ Make deploy optional for functions

### DIFF
--- a/nedryland/function.nix
+++ b/nedryland/function.nix
@@ -12,7 +12,7 @@ let
       '';
     };
 
-  mkFunction = attrs@{ name, package, manifest, code, ... }:
+  mkFunction = attrs@{ name, package, manifest, code, deploy ? true, ... }:
     let
       manifestGenerator = pkgs.callPackage ./manifest.nix {
         inherit name;
@@ -30,10 +30,13 @@ let
     base.mkComponent (
       attrs // {
         package = packageWithManifest;
-        deployment = {
-          function = deployFunction { package = packageWithManifest; };
-        };
-      }
+      } // (
+        if deploy then {
+          deployment = {
+            function = deployFunction { package = packageWithManifest; };
+          };
+        } else { }
+      )
     );
 in
 base.extend.mkExtension {


### PR DESCRIPTION
Some "functions" should not be deployed (one example is the python
bundle in start-blender that uses `mkDCCFunction` for convenience but it
does not make sense to deploy it).