### PR TITLE
👷 Use keepalive on the client as well

### DIFF
--- a/.github/workflows/ssh_agent.sh
+++ b/.github/workflows/ssh_agent.sh
@@ -13,6 +13,7 @@ echo "$CI_ACCESS_KEY" | tr -d '\r' | ssh-add -
 ##
 
 echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+echo "NIX_SSHOPTS='-o ServerAliveInterval=15 -o ServerAliveCountMax=150'" >> $GITHUB_ENV
 
 # set up for root
 sudo mkdir -p /root/.ssh


### PR DESCRIPTION
The corresponding settings are already set on the nix builders server
side. However, it seems like the server becomes unavailable for a short
while sometimes which means it cannot do keepalive so let's try to do it
on the client as well.