### PR TITLE
🐛 Fix quinn HTTPS storage for host-only urls

### DIFF
--- a/services/quinn/src/storage/https.rs
+++ b/services/quinn/src/storage/https.rs
@@ -11,7 +11,7 @@ pub struct HttpsStorage {
 
 impl HttpsStorage {
     pub fn new(base: &Url, auth: AuthMethod) -> Result<Self, StorageError> {
-        if base.cannot_be_a_base() || !base.as_str().ends_with('/') {
+        if base.cannot_be_a_base() || !base.path().ends_with('/') {
             Err(StorageError::BackendError(
                 "Url provided to Https Storage can not be used as a base".into(),
             ))
@@ -54,6 +54,28 @@ mod tests {
 
         let expected_storage_path = format!("https://example.net/submarine/{}", uuid_str);
         let base: Url = Url::parse("https://example.net/submarine/").unwrap();
+        let https_storage = HttpsStorage::new(&base, AuthMethod::Oauth2).unwrap();
+
+        let res = https_storage.get_upload_url(&FunctionAttachment {
+            id: Uuid::parse_str(uuid_str).unwrap(),
+            function_ids: vec![],
+            data: FunctionAttachmentData {
+                name: "Nej".to_owned(),
+                metadata: HashMap::new(),
+                checksums: Checksums {
+                    sha256: "nej".to_owned(),
+                },
+            },
+        });
+
+        assert!(res.is_ok());
+        let resp = res.unwrap();
+        assert_eq!(resp.url, expected_storage_path);
+        assert_eq!(resp.auth_method, super::AuthMethod::Oauth2 as i32);
+
+        // test host-only url
+        let expected_storage_path = format!("https://example.net/{}", uuid_str);
+        let base: Url = Url::parse("https://example.net").unwrap();
         let https_storage = HttpsStorage::new(&base, AuthMethod::Oauth2).unwrap();
 
         let res = https_storage.get_upload_url(&FunctionAttachment {


### PR DESCRIPTION
It assumed that the URL always had to end with '/' which is not the case
for urls without a path (like https://example.com).