### PR TITLE
🔥 [PIPE-1263] Remove extra credentials in lomax

### DIFF
--- a/clients/lomax/src/attachments.rs
+++ b/clients/lomax/src/attachments.rs
@@ -115,8 +115,7 @@ impl AuthBuilder for reqwest::RequestBuilder {
     fn build_auth(self, upload_info: &AttachmentUploadResponse) -> reqwest::RequestBuilder {
         match gbk_protocols::functions::AuthMethod::from_i32(upload_info.auth_method) {
             Some(gbk_protocols::functions::AuthMethod::Oauth2) => self.bearer_auth(
-                std::env::var_os("ATTACHMENT_UPLOAD_OAUTH_TOKEN")
-                    .or_else(|| std::env::var_os("OAUTH_TOKEN"))
+                std::env::var_os("OAUTH_TOKEN")
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_default(),
             ),

--- a/extensions/function.nix
+++ b/extensions/function.nix
@@ -1,8 +1,8 @@
 { base, pkgs }:
 let
   deployFunction = { package }:
-    # TODO credentials must be removed. Need to have a local auth service for that. attachmentCredentials must be removed once we got a proxy.
-    { lomax, endpoint, port, credentials, attachmentCredentials ? "" }: pkgs.stdenv.mkDerivation ({
+    # TODO credentials must be removed. Need to have a local auth service for that.
+    { lomax, endpoint, port, credentials }: pkgs.stdenv.mkDerivation ({
       name = "deploy-${package.name}";
       inputPackage = package;
       inherit lomax;
@@ -12,8 +12,7 @@ let
         mkdir -p $out
         $lomax/bin/lomax --address ${endpoint} --port ${builtins.toString port} register $inputPackage/manifest.toml 2>&1 | tee $out/command-output
       '';
-    } // (if credentials != "" then { OAUTH_TOKEN = credentials; } else { })
-    // (if attachmentCredentials != "" then { ATTACHMENT_UPLOAD_OAUTH_TOKEN = attachmentCredentials; } else { }));
+    } // (if credentials != "" then { OAUTH_TOKEN = credentials; } else { }));
 
   mkFunction = attrs@{ name, package, manifest, code, deploy ? true, ... }:
     let


### PR DESCRIPTION
This is not needed anymore since the HTTP proxy for attachments does not
need access tokens for Google APIs, only identitiy tokens.