### PR TITLE
[PIPE-1269] ✨ Add config format for multiple registries

### DIFF
--- a/services/avery/Cargo.lock
+++ b/services/avery/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -117,6 +117,7 @@ name = "avery"
 version = "0.1.0"
 dependencies = [
  "async-stream 0.3.0",
+ "config",
  "firm-types",
  "flate2",
  "futures",
@@ -124,7 +125,7 @@ dependencies = [
  "prost",
  "regex",
  "semver 0.10.0",
- "serde",
+ "serde 1.0.117",
  "sha2",
  "slog",
  "slog-async",
@@ -149,13 +150,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
- "serde",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -219,9 +226,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
 
 [[package]]
 name = "cfg-if"
@@ -243,7 +250,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
  "time",
  "winapi 0.3.9",
 ]
@@ -270,6 +277,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom",
+ "rust-ini",
+ "serde 1.0.117",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -514,7 +537,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca8b296792113e1500fd935ae487be6e00ce318952a6880555554824d6ebf38"
 dependencies = [
- "serde",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -703,7 +726,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -723,7 +746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
 dependencies = [
  "cfg-if 0.1.10",
- "serde",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -876,7 +899,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "socket2",
  "tokio",
  "tower-service",
@@ -903,7 +926,7 @@ checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -978,10 +1001,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
+dependencies = [
+ "serde 0.8.23",
+ "serde_test",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "lock_api"
@@ -1115,13 +1167,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1212,11 +1284,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -1232,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1246,6 +1318,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -1469,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "c5911690c9b773bab7e657471afc207f3827b249a657241327e3544d79bcabdd"
 dependencies = [
  "cc",
  "libc",
@@ -1484,15 +1562,21 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.0",
 ]
+
+[[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc_version"
@@ -1509,7 +1593,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "log",
  "ring",
  "sct",
@@ -1527,6 +1611,12 @@ dependencies = [
  "schannel",
  "security-framework",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schannel"
@@ -1603,6 +1693,12 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
@@ -1617,7 +1713,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d733da87e79faaac25616e33d26299a41143fd4cd42746cbb0e91d8feea243fd"
 dependencies = [
  "byteorder",
- "serde",
+ "serde 1.0.117",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static",
+ "linked-hash-map 0.3.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -1626,7 +1735,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -1638,6 +1747,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde 1.0.117",
+]
+
+[[package]]
+name = "serde_test"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
+dependencies = [
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -1701,17 +1830,17 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -1722,6 +1851,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1761,9 +1896,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1869,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1898,7 +2033,7 @@ dependencies = [
  "mio",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -1938,7 +2073,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -1948,7 +2083,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
- "serde",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -1959,7 +2094,7 @@ checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
 dependencies = [
  "async-stream 0.2.1",
  "async-trait",
- "base64",
+ "base64 0.12.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2163,13 +2298,13 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2225,7 +2360,7 @@ dependencies = [
  "erased-serde",
  "inventory",
  "lazy_static",
- "serde",
+ "serde 1.0.117",
  "typetag-impl",
 ]
 
@@ -2251,18 +2386,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -2301,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "rand",
- "serde",
+ "serde 1.0.117",
 ]
 
 [[package]]
@@ -2411,7 +2546,7 @@ dependencies = [
  "libc",
  "nix",
  "rayon",
- "serde",
+ "serde 1.0.117",
  "serde-bench",
  "serde_bytes",
  "serde_derive",
@@ -2458,7 +2593,7 @@ checksum = "c92a9ae96b193c35c47fc829265198322cf980edc353a9de32bc87a1545d44f3"
 dependencies = [
  "lazy_static",
  "memmap",
- "serde",
+ "serde 1.0.117",
  "serde_derive",
  "wasmer-clif-backend",
  "wasmer-runtime-core",
@@ -2483,7 +2618,7 @@ dependencies = [
  "page_size",
  "parking_lot",
  "rustc_version",
- "serde",
+ "serde 1.0.117",
  "serde-bench",
  "serde_bytes",
  "serde_derive",
@@ -2505,7 +2640,7 @@ dependencies = [
  "getrandom",
  "libc",
  "log",
- "serde",
+ "serde 1.0.117",
  "thiserror",
  "time",
  "typetag",
@@ -2602,4 +2737,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+dependencies = [
+ "linked-hash-map 0.5.3",
 ]

--- a/services/avery/Cargo.toml
+++ b/services/avery/Cargo.toml
@@ -5,28 +5,29 @@ authors = ["GBK Pipeline Team <pipeline@goodbyekansas.com>"]
 edition = "2018"
 
 [dependencies]
+async-stream = "0.3"
+config = "0.10"
+flate2 = "1"
+futures = "0.3"
+hex = "0.4"
 prost = "0.6"
 regex = "1"
 semver = "0.10"
 serde = "1"
+sha2 = "0.9"
 slog = "2"
 slog-async = "2"
 slog-term = "2"
 structopt = "0.3"
+tar = "0.4"
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "macros", "uds", "signal"] }
 toml = "0.5"
+typetag = "0.1"
 url = "2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 wasmer-runtime = "0.17"
 wasmer-wasi = "0.17"
-futures = "0.3"
-typetag = "0.1"
-async-stream = "0.3"
-sha2 = "0.9"
-hex = "0.4"
-flate2 = "1"
-tar = "0.4"
 
 firm-types = { version="0.1", registry = "nix" }

--- a/services/avery/avery.nix
+++ b/services/avery/avery.nix
@@ -3,7 +3,6 @@ with pkgs;
 base.languages.rust.mkService {
   name = "avery";
   src = ./.;
-  externalDependenciesHash = "sha256-P8sPV/IuQHp5Jh89e1FtUZUi0+sxj1xsLP0pNJ3S3GU=";
-  nativeBuildInputs = pkgs.stdenv.lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
-  buildInputs = [ types.package ];
+  externalDependenciesHash = "sha256-sh8Ea6t1BhxHu1R0XkSbYAWVT0YkJbnR8q/8Riz253k=";
+  buildInputs = [ types.package ] ++ pkgs.stdenv.lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
 }

--- a/services/avery/src/config.rs
+++ b/services/avery/src/config.rs
@@ -1,0 +1,140 @@
+use std::path::Path;
+
+use config::{ConfigError, Environment, File, FileFormat};
+use serde::Deserialize;
+
+fn default_port() -> u64 {
+    1939
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    #[serde(default = "default_port")]
+    pub port: u64,
+
+    #[serde(default)]
+    pub registries: Vec<Registry>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub struct Registry {
+    pub name: String,
+    pub url: String,
+    pub oauth_scope: Option<String>,
+}
+
+const DEFAULT_CFG_FILE_NAME: &str = "avery.toml";
+const ENVIRONMENT_PREFIX: &str = "AVERY";
+
+impl Config {
+    pub fn new() -> Result<Self, ConfigError> {
+        let mut c = config::Config::new();
+
+        // try some default config file locations
+        let current_folder_cfg = Path::new(DEFAULT_CFG_FILE_NAME);
+        if current_folder_cfg.exists() {
+            c.merge(File::from(current_folder_cfg))?;
+        } else {
+            #[cfg(unix)]
+            {
+                let etc_path = Path::new("/etc/avery").join(DEFAULT_CFG_FILE_NAME);
+                if etc_path.exists() {
+                    c.merge(File::from(etc_path))?;
+                }
+            }
+        }
+
+        c.merge(Environment::with_prefix(ENVIRONMENT_PREFIX))?;
+
+        c.try_into()
+    }
+
+    #[allow(dead_code)]
+    pub fn new_with_toml_string<S: AsRef<str>>(cfg: S) -> Result<Self, ConfigError> {
+        let mut c = config::Config::new();
+        c.merge(File::from_str(cfg.as_ref(), FileFormat::Toml))?;
+        c.merge(Environment::with_prefix(ENVIRONMENT_PREFIX))?;
+
+        c.try_into()
+    }
+
+    pub fn new_with_file<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
+        let mut c = config::Config::new();
+        c.merge(File::from(path.as_ref()))?;
+        c.merge(Environment::with_prefix(ENVIRONMENT_PREFIX))?;
+
+        c.try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let c = Config::new_with_toml_string("");
+
+        assert!(c.is_ok());
+        assert_eq!(c.unwrap().port, default_port());
+    }
+
+    #[test]
+    fn ports() {
+        // Read the port 🛳️
+        let c = Config::new_with_toml_string(
+            r#"
+        port=1337
+        "#,
+        );
+        assert!(c.is_ok());
+        assert_eq!(c.unwrap().port, 1337);
+    }
+
+    #[test]
+    fn registries() {
+        // Test registries in config, make sure oath_scope is optional
+        let c = Config::new_with_toml_string(
+            r#"
+        [[registries]]
+        name="registry1"
+        url="https://over-here"
+
+        [[registries]]
+        name="registry3"
+        url="https://on-the-internet.com"
+        oauth_scope="everything"
+        "#,
+        );
+        assert!(c.is_ok());
+        assert_eq!(
+            c.unwrap().registries,
+            vec![
+                Registry {
+                    name: "registry1".to_owned(),
+                    url: "https://over-here".to_owned(),
+                    oauth_scope: None
+                },
+                Registry {
+                    name: "registry3".to_owned(),
+                    url: "https://on-the-internet.com".to_owned(),
+                    oauth_scope: Some("everything".to_owned())
+                }
+            ]
+        );
+        // Non optional things should cause error if missing
+        let c = Config::new_with_toml_string(
+            r#"
+        [[registries]]
+        name="registry-without-url"
+
+        [[registries]]
+        name="registry3"
+        url="https://on-the-internet.com"
+        oauth_scope="everything"
+        "#,
+        );
+        assert!(c.is_err());
+    }
+}

--- a/services/avery/src/main.rs
+++ b/services/avery/src/main.rs
@@ -1,4 +1,4 @@
-use slog::{info, o, Drain};
+use slog::{error, info, o, Drain, Logger};
 use structopt::StructOpt;
 
 use firm_types::{
@@ -7,6 +7,9 @@ use firm_types::{
 };
 
 use avery::{executor::ExecutionService, registry::RegistryService};
+use std::path::PathBuf;
+
+mod config;
 
 // clean exit on crtl c
 async fn ctrlc() {
@@ -15,26 +18,25 @@ async fn ctrlc() {
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "avery")]
-struct AveryArgs {}
+struct AveryArgs {
+    #[structopt(short = "c", long = "config", parse(from_os_str), env = "AVERY_CONFIG")]
+    config: Option<PathBuf>,
+}
 
-// local server main loop
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
+async fn run(log: Logger) -> Result<(), Box<dyn std::error::Error>> {
+    let args = AveryArgs::from_args();
 
-    let log = slog::Logger::root(drain, o!());
-
-    let _args = AveryArgs::from_args();
-
-    let port: u32 = 1939;
+    let config = args
+        .config
+        .map_or_else(config::Config::new, config::Config::new_with_file)?;
+    let port = config.port;
     let addr = format!("[::]:{}", port).parse().unwrap();
-    let functions_registry_service = RegistryService::new(log.new(o!("service" => "registry")));
+
+    let internal_registry = RegistryService::new(log.new(o!("service" => "internal-registry")));
 
     let execution_service = ExecutionService::new(
         log.new(o!("service" => "functions")),
-        Box::new(functions_registry_service.clone()),
+        Box::new(internal_registry.clone()),
     );
 
     info!(
@@ -44,10 +46,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Server::builder()
         .add_service(ExecutionServer::new(execution_service))
-        .add_service(RegistryServer::new(functions_registry_service))
+        .add_service(RegistryServer::new(internal_registry))
         .serve_with_shutdown(addr, ctrlc())
         .await?;
 
     info!(log, "👋 see you soon - no one leaves the Firm");
     Ok(())
+}
+
+// local server main loop
+#[tokio::main]
+async fn main() -> Result<(), i32> {
+    let decorator = slog_term::TermDecorator::new().build();
+    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).build().fuse();
+    let log = Logger::root(drain, o!());
+
+    let exit_log = log.new(o!("scope" => "unhandled_error"));
+    run(log).await.map_err(|e| {
+        error!(exit_log, "Unhandled error: {}. Exiting", e);
+        1i32
+    })
 }


### PR DESCRIPTION
The default config file location is, in order:
- avery.toml in the current directory
- avery.toml in /etc/avery on Unix platforms

Configuration can be override by sending the argument `--config` (`-c`)
with the configuration file location. It can also fall back to an
environment variable `AVERY_CONFIG`. All values in the config can also
be set with environment variables `AVERY_<setting>`.