### PR TITLE
⬆️ 🔥 Update nedryland and remove rust vendoring

### DIFF
--- a/clients/bendini/bendini.nix
+++ b/clients/bendini/bendini.nix
@@ -5,6 +5,4 @@ base.languages.rust.mkClient {
   buildInputs = [ types.package tonicMiddleware.package ]
     ++ pkgs.stdenv.lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
   nativeBuildInputs = [ pkgs.pkg-config pkgs.openssl ];
-
-  externalDependenciesHash = "sha256-2DODt6t884Ju+wyfD4koW5mGiD/dDlL3EZTr2seCnSQ=";
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -2,7 +2,7 @@
     "nedryland": {
         "branch": "main",
         "repo": "git@github.com:goodbyekansas/nedryland",
-        "rev": "9274eb491837a9c04b95733daf578e2e331aed83",
+        "rev": "ccbce2759d20967bdff06f1081b89c460ee2a410",
         "type": "git"
     },
     "niv": {

--- a/services/avery/avery.nix
+++ b/services/avery/avery.nix
@@ -5,6 +5,4 @@ base.languages.rust.mkService {
   src = ./.;
   buildInputs = [ types.package tonicMiddleware.package ] ++ pkgs.stdenv.lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
   nativeBuildInputs = pkgs.stdenv.lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.xcbuild;
-
-  externalDependenciesHash = "sha256-QcYvBojWLbh3uVAbeBCc63SV9Yi0oNrRv0a+e4u+yLs=";
 }

--- a/services/quinn/quinn.nix
+++ b/services/quinn/quinn.nix
@@ -6,8 +6,6 @@ base.languages.rust.mkService {
   buildInputs = [ types.package pkgs.openssl ]
     ++ pkgs.stdenv.lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
 
-  externalDependenciesHash = "sha256-foZ5LA4L7+Oc96mrAtCNT9blUlfeKhxtQRWSBwSlWwk=";
-
   nativeBuildInputs = [ pkgs.postgresql pkgs.coreutils pkgs.pkg-config ];
 
   extraChecks = ''


### PR DESCRIPTION
This removes the need for `externalDependenciesHash`. It does not break
by having it there either but remove it for cleanliness.