### PR TITLE
[PIPE-1535] 🔨 Refactor runtime wrapping in avery

### DIFF
--- a/protocols/firm_protocols/wasi/wasi.proto
+++ b/protocols/firm_protocols/wasi/wasi.proto
@@ -13,7 +13,8 @@ message StartProcessRequest {
   map<string, string> environment_variables = 3;
 }
 
-message Attachments {
-  repeated firm_protocols.functions.Attachment attachments = 1;
+message RuntimeContext {
+  firm_protocols.functions.Attachment code = 1;
+  string entrypoint = 2;
+  map<string, string> arguments = 3;
 }
-

--- a/runtimes/python/Cargo.toml
+++ b/runtimes/python/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["GBK Pipeline Team <pipeline@goodbyekansas.com>"]
 edition = "2018"
 
 [dependencies]
-firm = { version = "0.1", registry="nix", features=["net"] }
-firm-types = { version = "0.1", registry="nix" }
+firm = { version = "0.1", registry="nix", features=["net", "runtime"] }
 
 wasi-python-shims = { version = "0.1", registry="nix" }
 

--- a/utils/rust/firm-rust/Cargo.toml
+++ b/utils/rust/firm-rust/Cargo.toml
@@ -16,4 +16,5 @@ lazy_static = "1"
 
 [features]
 net = []
+runtime = []
 mock = ["lazy_static"]

--- a/utils/rust/firm-rust/firm-rust.nix
+++ b/utils/rust/firm-rust/firm-rust.nix
@@ -4,8 +4,8 @@ base.languages.rust.mkUtility {
   src = ./.;
   defaultTarget = "wasm32-wasi";
   targets = [ "wasm32-wasi" ];
-  useNightly = "2020-10-25";
+  useNightly = "2021-01-27";
   propagatedBuildInputs = [ types.package ];
   testFeatures = [ "net" "mock" ];
-  buildFeatures = [ "net" ];
+  buildFeatures = [ "net" "runtime" ];
 }


### PR DESCRIPTION
Instead of abusing inputs we now serialize the runtime context with
protobuf to a file that gets mapped into the runtime. The idea is that
the runtime parses this file to obtain context.