### PR TITLE
✨ Provide avery with runtimes function

### DIFF
--- a/project.nix
+++ b/project.nix
@@ -42,6 +42,9 @@ nedryland.mkProject {
       types = firmTypes.rust.withServices;
     };
 
+    averyWithRuntimes = callFile ./services/avery/avery-with-runtimes.nix { };
+    averyWithDefaultRuntimes = (callFile ./services/avery/avery-with-runtimes.nix { }) { };
+
     bendini = callFile ./clients/bendini/bendini.nix {
       types = firmTypes.rust.withServices;
     };

--- a/services/avery/avery-with-runtimes.nix
+++ b/services/avery/avery-with-runtimes.nix
@@ -1,0 +1,38 @@
+{ stdenv, base, runtimes, avery, makeWrapper }:
+let
+  flattenAttrs = attrs: builtins.map (value: value.package) (builtins.attrValues attrs);
+  flattenedRuntimes = flattenAttrs runtimes;
+in
+{ additionalRuntimes ? { } }:
+let
+  flattenedAdditionalRuntimes =
+    if builtins.isList additionalRuntimes then
+      additionalRuntimes
+    else
+      flattenAttrs additionalRuntimes;
+in
+base.mkComponent {
+  name = "avery-bundle";
+  package = stdenv.mkDerivation {
+    name = "avery-bundle";
+    runtimes = flattenedRuntimes ++ flattenedAdditionalRuntimes;
+    avery = avery.package;
+    nativeBuildInputs = [ makeWrapper ];
+
+    builder = builtins.toFile "builder.sh" ''
+      source $stdenv/setup
+      mkdir -p $out
+
+      cp -r --no-preserve=mode $avery/. $out
+      chmod +x $out/bin/avery
+
+      for runtime in $runtimes; do
+        cp -r $runtime/. $out
+      done
+
+      mkdir -p $out/etc/avery
+      echo "{\"runtime_directories\": [\"$out/share/avery/runtimes\"]}" >$out/etc/avery/avery.json
+      wrapProgram $out/bin/avery --set AVERY_CONFIG $out/etc/avery/avery.json;
+    '';
+  };
+}


### PR DESCRIPTION
This function allows for creating a derivation that contains Avery and
the passed in runtimes. Avery is also set up to read all the runtimes
when Avery is launched.

There is also an avery with default runtimes. This is if you want to
use avery with the shipped runtimes but do not want to add any of your
own. The attribute `avery` is still the raw package.