### PR TITLE
✨ [PIPE-1601] Add an internal Unix domain socket for Avery

### DIFF
--- a/clients/bendini/.envrc
+++ b/clients/bendini/.envrc
@@ -1,1 +1,3 @@
-use nix ../../shell.nix -A bendini
+if [ -z "$IN_NIX_SHELL" ]; then
+    use nix ../../shell.nix -A bendini
+fi

--- a/clients/bendini/Cargo.lock
+++ b/clients/bendini/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "firm-types",
  "futures",
  "indicatif",
- "prost 0.7.0",
+ "prost",
  "rand",
  "regex",
  "reqwest",
@@ -109,6 +109,7 @@ dependencies = [
  "tokio",
  "toml",
  "tonic-middleware",
+ "tower",
  "url",
 ]
 
@@ -123,12 +124,6 @@ name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -220,8 +215,8 @@ name = "firm-protocols"
 version = "0.1.0"
 source = "registry+https://fake-nix-registry/not-really-an-index"
 dependencies = [
- "bytes 1.0.1",
- "prost 0.7.0",
+ "bytes",
+ "prost",
  "tempfile",
  "tonic",
 ]
@@ -232,7 +227,7 @@ version = "0.1.0"
 source = "registry+https://fake-nix-registry/not-really-an-index"
 dependencies = [
  "firm-protocols",
- "prost 0.6.1",
+ "prost",
  "thiserror",
 ]
 
@@ -361,7 +356,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -404,7 +399,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -415,7 +410,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
 ]
 
@@ -437,7 +432,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -508,15 +503,6 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -732,35 +718,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
-dependencies = [
- "bytes 0.5.6",
- "prost-derive 0.6.1",
-]
-
-[[package]]
-name = "prost"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 1.0.1",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
-dependencies = [
- "anyhow",
- "itertools 0.8.2",
- "proc-macro2",
- "quote",
- "syn",
+ "bytes",
+ "prost-derive",
 ]
 
 [[package]]
@@ -770,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -868,7 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
 dependencies = [
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1176,7 +1139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
  "mio",
@@ -1224,7 +1187,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -1250,7 +1213,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-util",
  "h2",
@@ -1259,8 +1222,8 @@ dependencies = [
  "hyper",
  "percent-encoding",
  "pin-project",
- "prost 0.7.0",
- "prost-derive 0.7.0",
+ "prost",
+ "prost-derive",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",

--- a/clients/bendini/Cargo.toml
+++ b/clients/bendini/Cargo.toml
@@ -21,6 +21,7 @@ structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml = "0.5"
+tower = "0.4"
 url = "2"
 
 firm-types = { version = "0.1", registry = "nix" }

--- a/clients/bendini/src/commands/list_runtimes.rs
+++ b/clients/bendini/src/commands/list_runtimes.rs
@@ -1,10 +1,10 @@
 use firm_types::{functions::execution_client::ExecutionClient, functions::RuntimeFilters, tonic};
-use tonic::transport::Channel;
+use tonic_middleware::HttpStatusInterceptor;
 
 use crate::{error, formatting::DisplayExt};
 
 pub async fn run(
-    mut client: ExecutionClient<Channel>,
+    mut client: ExecutionClient<HttpStatusInterceptor>,
     name: String,
 ) -> Result<(), error::BendiniError> {
     println!("Listing runtimes");

--- a/clients/bendini/src/commands/run.rs
+++ b/clients/bendini/src/commands/run.rs
@@ -7,7 +7,7 @@ use firm_types::{
         VersionRequirement,
     },
     stream::ToChannel,
-    tonic::{self, transport::Channel},
+    tonic,
 };
 use futures::{join, FutureExt, StreamExt, TryFutureExt};
 use tonic_middleware::HttpStatusInterceptor;
@@ -121,7 +121,7 @@ where
 
 pub async fn run(
     mut registry_client: RegistryClient<HttpStatusInterceptor>,
-    mut execution_client: ExecutionClient<Channel>,
+    mut execution_client: ExecutionClient<HttpStatusInterceptor>,
     function_id: String,
     arguments: Vec<(String, String)>,
     follow_output: bool,

--- a/extensions/nedryland/function.nix
+++ b/extensions/nedryland/function.nix
@@ -3,12 +3,11 @@ let
   deployFunction = package:
     pkgs.lib.makeOverridable
       (
-        { endpoint ? "tcp://[::1]", port ? 1939 }: base.deployment.mkDeployment {
+        { host ? null }: base.deployment.mkDeployment {
           name = "deploy-${package.name}";
           deployPhase = ''
-            SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ${bendini.package}/bin/bendini \
-            --address ${endpoint} \
-            --port ${builtins.toString port} \
+            ${bendini.package}/bin/bendini \
+            ${if host != null then "--host ${host} \\" else ""}
             register ${package}/manifest.toml
           '';
         }

--- a/services/avery/src/config.rs
+++ b/services/avery/src/config.rs
@@ -11,13 +11,20 @@ fn default_enabled() -> bool {
     true
 }
 
+fn default_internal_port_socket_path() -> PathBuf {
+    PathBuf::from("/tmp/avery.sock")
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Config {
     #[serde(default = "default_port")]
     pub port: u64,
 
     #[serde(default = "default_enabled")]
-    pub enable_global_port: bool,
+    pub enable_external_port: bool,
+
+    #[serde(default = "default_internal_port_socket_path")]
+    pub internal_port_socket_path: PathBuf,
 
     #[serde(default)]
     pub registries: Vec<Registry>,


### PR DESCRIPTION
The internal socket is a unix domain socket that is only accessible
from localhost. The idea is that the TCP port is used for external
communication and the UDS is used for internal communication.

Currently only works on UNIX platforms, Windows is up next.

Also fix the deployment function:

Stop using a fixed SSL cert bundle. It is important that the SSL
bundle used gets updates even though the deploy script might
not. Therefore, we need to use the system SSL bundle.