### PR TITLE
✨ [PIPE-1602] Windows named pipe support for Avery and Bendini

### DIFF
--- a/clients/bendini/Cargo.lock
+++ b/clients/bendini/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
 
 [[package]]
 name = "async-stream"
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc80946b3480f421c2f17ed1cb841753a371c7c5104f51d507e13f532c856aa"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -406,12 +406,13 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
  "bytes",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -478,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -521,9 +522,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -536,9 +537,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
 name = "log"
@@ -569,9 +570,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
 dependencies = [
  "libc",
  "log",
@@ -655,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf491442e4b033ed1c722cb9f0df5fcfcf4de682466c46469c36bc47dc5548a"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -799,21 +800,20 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "base64",
  "bytes",
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
+checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -950,18 +950,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1109,15 +1109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,25 +1125,25 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+version = "1.3.0"
+source = "git+https://github.com/goodbyekansas/tokio.git?branch=named-pipes-1.3.0#ad62019b58a59968e0748e683965da06657c114e"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
+ "miow",
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
+ "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+source = "git+https://github.com/goodbyekansas/tokio.git?branch=named-pipes-1.3.0#ad62019b58a59968e0748e683965da06657c114e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1172,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1183,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1206,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
+checksum = "91491e5f15431f2189ec8c1f9dcbadac949450399c22c912ceae9570eb472f61"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1291,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1387,9 +1378,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"
@@ -1409,9 +1400,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1421,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1436,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1448,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1458,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1471,15 +1462,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/clients/bendini/Cargo.toml
+++ b/clients/bendini/Cargo.toml
@@ -19,13 +19,22 @@ reqwest = { version = "0.11", features = ["rustls-tls"], default-features = fals
 serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
 thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+# use `=` here to match our fork belowf
+# TODO: update fork to 1.4.0
+tokio = { version = "=1.3.0", features = ["rt-multi-thread", "macros", "net"] }
+
 toml = "0.5"
 tower = "0.4"
 url = "2"
 
 firm-types = { version = "0.1", registry = "nix" }
 tonic-middleware = { version = "0.1", registry = "nix" }
+
+# our own version of tokio 1.3.0 with named pipes
+[patch.crates-io]
+tokio = {  git = "https://github.com/goodbyekansas/tokio.git", branch="named-pipes-1.3.0" }
+
 
 [dev-dependencies]
 tempfile = "3"

--- a/clients/bendini/bendini.nix
+++ b/clients/bendini/bendini.nix
@@ -1,8 +1,9 @@
-{ pkgs, base, types, tonicMiddleware }:
+{ pkgs, base, types, tonicMiddleware, stdenv, targets ? [ ], defaultTarget ? "", pkgsCross ? null }:
 base.languages.rust.mkClient {
+  inherit stdenv targets defaultTarget;
   name = "bendini";
   src = ./.;
   buildInputs = [ types.package tonicMiddleware.package ]
-    ++ pkgs.stdenv.lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
+    ++ stdenv.lib.optional stdenv.hostPlatform.isWindows pkgsCross.mingwW64.windows.pthreads;
   nativeBuildInputs = [ pkgs.pkg-config pkgs.openssl ];
 }

--- a/project.nix
+++ b/project.nix
@@ -42,14 +42,23 @@ nedryland.mkProject {
     avery = callFile ./services/avery/avery.nix {
       types = firmTypes.rust.withServices;
     };
+    windows = {
+      avery = callFunction
+        ({ pkgsCross }: avery.override {
+          stdenv = pkgsCross.mingwW64.stdenv;
+          targets = [ "x86_64-pc-windows-gnu" ];
+          defaultTarget = "x86_64-pc-windows-gnu";
+        }) ./services/avery
+        { };
 
-    averyWindows = callFunction
-      ({ pkgsCross }: avery.override {
-        stdenv = pkgsCross.mingwW64.stdenv;
-        targets = [ "x86_64-pc-windows-gnu" ];
-        defaultTarget = "x86_64-pc-windows-gnu";
-      }) ./services/avery
-      { };
+      bendini = callFunction
+        ({ pkgsCross }: bendini.override {
+          stdenv = pkgsCross.mingwW64.stdenv;
+          targets = [ "x86_64-pc-windows-gnu" ];
+          defaultTarget = "x86_64-pc-windows-gnu";
+        }) ./clients/bendini
+        { };
+    };
 
     averyWithRuntimes = callFile ./services/avery/avery-with-runtimes.nix { };
     averyWithDefaultRuntimes = (callFile ./services/avery/avery-with-runtimes.nix { }) { };

--- a/services/avery/Cargo.lock
+++ b/services/avery/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
 
 [[package]]
 name = "arrayvec"
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -107,7 +107,7 @@ dependencies = [
  "prost",
  "regex",
  "semver",
- "serde 1.0.123",
+ "serde 1.0.124",
  "sha2",
  "slog",
  "slog-async",
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
 dependencies = [
  "byteorder",
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.123",
+ "serde 1.0.124",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -323,7 +323,7 @@ version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86badbce14e15f52a45b666b38abe47b204969dd7f8fb7488cb55dd46b361fa6"
 dependencies = [
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
 dependencies = [
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
@@ -669,7 +669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
 dependencies = [
  "cfg-if 0.1.10",
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
@@ -783,12 +783,13 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
  "bytes",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -846,13 +847,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
@@ -894,9 +895,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -928,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
 name = "libloading"
@@ -1018,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
 dependencies = [
  "libc",
  "log",
@@ -1174,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf491442e4b033ed1c722cb9f0df5fcfcf4de682466c46469c36bc47dc5548a"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1364,21 +1365,20 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "region"
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
+checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1546,9 +1546,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
@@ -1572,14 +1572,14 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1594,7 +1594,7 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1860,15 +1860,15 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+version = "1.3.0"
+source = "git+https://github.com/goodbyekansas/tokio.git?branch=named-pipes-1.3.0#ad62019b58a59968e0748e683965da06657c114e"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
+ "miow",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
@@ -1880,8 +1880,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+source = "git+https://github.com/goodbyekansas/tokio.git?branch=named-pipes-1.3.0#ad62019b58a59968e0748e683965da06657c114e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1901,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1912,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1930,14 +1929,14 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
+checksum = "91491e5f15431f2189ec8c1f9dcbadac949450399c22c912ceae9570eb472f61"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2020,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2056,9 +2055,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "typetag"
@@ -2069,7 +2068,7 @@ dependencies = [
  "erased-serde",
  "inventory",
  "lazy_static",
- "serde 1.0.123",
+ "serde 1.0.124",
  "typetag-impl",
 ]
 
@@ -2151,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
- "serde 1.0.123",
+ "serde 1.0.124",
 ]
 
 [[package]]
@@ -2162,9 +2161,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"
@@ -2184,9 +2183,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2194,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2209,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2219,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2232,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
 
 [[package]]
 name = "wasmer"
@@ -2266,7 +2265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b7732a9cab472bd921d5a0c422f45b3d03f62fa2c40a89e0770cef6d47e383e"
 dependencies = [
  "enumset",
- "serde 1.0.123",
+ "serde 1.0.124",
  "serde_bytes",
  "smallvec",
  "target-lexicon",
@@ -2287,7 +2286,7 @@ dependencies = [
  "gimli 0.22.0",
  "more-asserts",
  "rayon",
- "serde 1.0.123",
+ "serde 1.0.124",
  "smallvec",
  "tracing",
  "wasmer-compiler",
@@ -2319,7 +2318,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde 1.0.123",
+ "serde 1.0.124",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -2337,7 +2336,7 @@ dependencies = [
  "bincode",
  "cfg-if 0.1.10",
  "region",
- "serde 1.0.123",
+ "serde 1.0.124",
  "serde_bytes",
  "wasmer-compiler",
  "wasmer-engine",
@@ -2356,7 +2355,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "leb128",
  "libloading",
- "serde 1.0.123",
+ "serde 1.0.124",
  "tempfile",
  "tracing",
  "wasmer-compiler",
@@ -2386,7 +2385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f4ac28c2951cd792c18332f03da523ed06b170f5cf6bb5b1bdd7e36c2a8218"
 dependencies = [
  "cranelift-entity",
- "serde 1.0.123",
+ "serde 1.0.124",
  "thiserror",
 ]
 
@@ -2404,7 +2403,7 @@ dependencies = [
  "memoffset",
  "more-asserts",
  "region",
- "serde 1.0.123",
+ "serde 1.0.124",
  "thiserror",
  "wasmer-types",
  "winapi",
@@ -2421,7 +2420,7 @@ dependencies = [
  "generational-arena",
  "getrandom",
  "libc",
- "serde 1.0.123",
+ "serde 1.0.124",
  "thiserror",
  "time",
  "tracing",
@@ -2456,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/services/avery/Cargo.toml
+++ b/services/avery/Cargo.toml
@@ -22,7 +22,11 @@ structopt = "0.3"
 tar = "0.4"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "time", "macros", "net", "signal"] }
+
+# use `=` here to match our fork belowf
+# TODO: update fork to 1.4.0
+tokio = { version = "=1.3.0", features = ["rt-multi-thread", "time", "macros", "net", "signal"] }
+
 toml = "0.5"
 typetag = "0.1"
 url = "2"
@@ -32,3 +36,7 @@ wasmer = "1"
 
 firm-types = { version = "0.1", registry = "nix" }
 tonic-middleware = { version = "0.1", registry = "nix" }
+
+# our own version of tokio 1.3.0 with named pipes
+[patch.crates-io]
+tokio = {  git = "https://github.com/goodbyekansas/tokio.git", branch="named-pipes-1.3.0" }

--- a/services/avery/src/config.rs
+++ b/services/avery/src/config.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use config::{ConfigError, Environment, File, FileFormat};
 use serde::Deserialize;
 
+use crate::system;
+
 fn default_port() -> u64 {
     1939
 }
@@ -12,7 +14,7 @@ fn default_enabled() -> bool {
 }
 
 fn default_internal_port_socket_path() -> PathBuf {
-    PathBuf::from("/tmp/avery.sock")
+    PathBuf::from(system::INTERNAL_PORT_PATH)
 }
 
 #[derive(Debug, Deserialize)]

--- a/services/avery/src/lib.rs
+++ b/services/avery/src/lib.rs
@@ -3,3 +3,13 @@ pub mod executor;
 pub mod proxy_registry;
 pub mod registry;
 pub mod runtime;
+
+#[cfg(unix)]
+pub mod unix;
+#[cfg(unix)]
+pub use unix as system;
+
+#[cfg(windows)]
+pub mod windows;
+#[cfg(windows)]
+pub use windows as system;

--- a/services/avery/src/main.rs
+++ b/services/avery/src/main.rs
@@ -1,9 +1,6 @@
 use slog::{error, info, o, Drain, Logger};
 use structopt::StructOpt;
 
-#[cfg(unix)]
-use firm_types::tonic;
-
 use firm_types::{
     functions::{execution_server::ExecutionServer, registry_server::RegistryServer},
     tonic::transport::Server,
@@ -14,48 +11,14 @@ use avery::{
     executor::ExecutionService,
     proxy_registry::{ExternalRegistry, ProxyRegistry},
     registry::RegistryService,
-    runtime,
+    runtime, system,
 };
-
-#[cfg(unix)]
-use futures::TryFutureExt;
 
 use futures::FutureExt;
 
 use std::{net::SocketAddr, path::PathBuf};
 
-#[cfg(unix)]
-use tokio::{
-    net::UnixListener,
-    signal::unix::{signal, SignalKind},
-};
-
 use url::Url;
-
-async fn ctrl_c() {
-    let _ = tokio::signal::ctrl_c().await;
-}
-
-#[cfg(unix)]
-async fn sig_term() {
-    match signal(SignalKind::terminate()) {
-        Ok(mut stream) => stream.recv().await,
-        Err(_) => futures::future::pending::<Option<()>>().await,
-    };
-}
-
-#[cfg(not(unix))]
-async fn shutdown_signal(_log: Logger) {
-    ctrl_c().await;
-}
-
-#[cfg(unix)]
-async fn shutdown_signal(log: Logger) {
-    futures::select! {
-        () = ctrl_c().fuse() => { info!(log, "Recieved Ctrl-C"); },
-        () = sig_term().fuse() => { info!(log, "Recieved SIGTERM"); }
-    }
-}
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "avery")]
@@ -73,98 +36,14 @@ async fn create_front_door(
     Server::builder()
         .add_service(ExecutionServer::new(execution_service))
         .add_service(RegistryServer::new(proxy_registry))
-        .serve_with_shutdown(addr, shutdown_signal(log.new(o!("scope" => "shutdown"))))
+        .serve_with_shutdown(
+            addr,
+            system::shutdown_signal(log.new(o!("scope" => "shutdown"))),
+        )
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn create_trap_door(
-    local_socket_path: &std::path::Path,
-    execution_service: ExecutionService,
-    proxy_registry: ProxyRegistry,
-    log: Logger,
-) -> Result<(), String> {
-    #[cfg(not(unix))]
-    {
-        let _a = local_socket_path;
-        let _b = execution_service;
-        let _c = proxy_registry;
-        let _e = log;
-        return Ok(());
-    }
-
-    #[cfg(unix)]
-    {
-        let incoming = {
-            let uds = UnixListener::bind(local_socket_path).map_err(|e| e.to_string())?;
-
-            async_stream::stream! {
-                while let item = uds.accept().map_ok(|(st, _)| unix::UnixStream(st)).await {
-                    yield item;
-                }
-            }
-        };
-
-        let server = Server::builder()
-            .add_service(ExecutionServer::new(execution_service))
-            .add_service(RegistryServer::new(proxy_registry))
-            .serve_with_incoming_shutdown(
-                incoming,
-                shutdown_signal(log.new(o!("scope" => "shutdown"))),
-            )
-            .await
-            .map_err(|e| e.to_string());
-        std::fs::remove_file(local_socket_path).unwrap_or(());
-        server
-    }
-}
-
-#[cfg(unix)]
-mod unix {
-    use std::{
-        pin::Pin,
-        task::{Context, Poll},
-    };
-
-    use super::tonic::transport::server::Connected;
-    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-
-    #[derive(Debug)]
-    pub struct UnixStream(pub tokio::net::UnixStream);
-
-    impl Connected for UnixStream {}
-
-    impl AsyncRead for UnixStream {
-        fn poll_read(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &mut ReadBuf<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.0).poll_read(cx, buf)
-        }
-    }
-
-    impl AsyncWrite for UnixStream {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            Pin::new(&mut self.0).poll_write(cx, buf)
-        }
-
-        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.0).poll_flush(cx)
-        }
-
-        fn poll_shutdown(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.0).poll_shutdown(cx)
-        }
-    }
-}
 async fn run(log: Logger) -> Result<(), Box<dyn std::error::Error>> {
     let args = AveryArgs::from_args();
 
@@ -226,10 +105,7 @@ async fn run(log: Logger) -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     let mut runtime_directories = config.runtime_directories.clone();
-    #[cfg(windows)]
-    runtime_directories.push(PathBuf::from("%PROGRAMDATA%/Avery/runtimes"));
-    #[cfg(unix)]
-    runtime_directories.push(PathBuf::from("/usr/share/avery/runtimes"));
+    runtime_directories.push(PathBuf::from(system::DEFAULT_RUNTIME_DIR));
     let directory_sources = runtime_directories
         .into_iter()
         .filter_map(|d| {
@@ -284,7 +160,7 @@ async fn run(log: Logger) -> Result<(), Box<dyn std::error::Error>> {
         &config.internal_port_socket_path.display()
     );
     futures::try_join!(
-        create_trap_door(
+        system::create_trap_door(
             &config.internal_port_socket_path,
             execution_service,
             proxy_registry,

--- a/services/avery/src/unix.rs
+++ b/services/avery/src/unix.rs
@@ -1,0 +1,97 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use firm_types::{
+    functions::{execution_server::ExecutionServer, registry_server::RegistryServer},
+    tonic::transport::{server::Connected, Server},
+};
+use futures::{FutureExt, TryFutureExt};
+use slog::{info, o, Logger};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::UnixListener,
+    signal::unix::{signal, SignalKind},
+};
+
+use crate::{executor::ExecutionService, proxy_registry::ProxyRegistry};
+
+pub const INTERNAL_PORT_PATH: &str = "/tmp/avery.sock";
+pub const DEFAULT_RUNTIME_DIR: &str = "/usr/share/avery/runtimes";
+
+pub async fn create_trap_door(
+    local_socket_path: &std::path::Path,
+    execution_service: ExecutionService,
+    proxy_registry: ProxyRegistry,
+    log: Logger,
+) -> Result<(), String> {
+    let incoming = {
+        let uds = UnixListener::bind(local_socket_path).map_err(|e| e.to_string())?;
+
+        async_stream::stream! {
+            while let item = uds.accept().map_ok(|(st, _)| UnixStream(st)).await {
+                yield item;
+            }
+        }
+    };
+
+    let server = Server::builder()
+        .add_service(ExecutionServer::new(execution_service))
+        .add_service(RegistryServer::new(proxy_registry))
+        .serve_with_incoming_shutdown(
+            incoming,
+            shutdown_signal(log.new(o!("scope" => "shutdown"))),
+        )
+        .await
+        .map_err(|e| e.to_string());
+    std::fs::remove_file(local_socket_path).unwrap_or(());
+    server
+}
+
+async fn sig_term() {
+    match signal(SignalKind::terminate()) {
+        Ok(mut stream) => stream.recv().await,
+        Err(_) => futures::future::pending::<Option<()>>().await,
+    };
+}
+
+pub async fn shutdown_signal(log: Logger) {
+    futures::select! {
+        () = tokio::signal::ctrl_c().map_ok_or_else(|_| (), |_| ()).fuse() => { info!(log, "Recieved Ctrl-C"); },
+        () = sig_term().fuse() => { info!(log, "Recieved SIGTERM"); }
+    }
+}
+
+#[derive(Debug)]
+struct UnixStream(pub tokio::net::UnixStream);
+
+impl Connected for UnixStream {}
+
+impl AsyncRead for UnixStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for UnixStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}

--- a/services/avery/src/windows.rs
+++ b/services/avery/src/windows.rs
@@ -1,0 +1,87 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use firm_types::{
+    functions::{execution_server::ExecutionServer, registry_server::RegistryServer},
+    tonic::transport::{server::Connected, Server},
+};
+use futures::TryFutureExt;
+use slog::{o, Logger};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::NamedPipeServerBuilder,
+};
+
+use crate::{executor::ExecutionService, proxy_registry::ProxyRegistry};
+
+pub const INTERNAL_PORT_PATH: &str = r#"\\.\pipe\avery"#;
+pub const DEFAULT_RUNTIME_DIR: &str = r#"%PROGRAMDATA%\Avery\runtimes"#;
+
+pub async fn create_trap_door(
+    local_socket_path: &std::path::Path,
+    execution_service: ExecutionService,
+    proxy_registry: ProxyRegistry,
+    log: Logger,
+) -> Result<(), String> {
+    let incoming = {
+        let pipe = NamedPipeServerBuilder::new(local_socket_path)
+            .with_accept_remote(false)
+            .build()
+            .map_err(|e| format!("Failed to create named pipe: {}", e))?;
+
+        async_stream::stream! {
+            while let item = pipe.accept().map_ok(|np| NamedPipe(np)).await {
+                yield item;
+            }
+        }
+    };
+
+    Server::builder()
+        .add_service(ExecutionServer::new(execution_service))
+        .add_service(RegistryServer::new(proxy_registry))
+        .serve_with_incoming_shutdown(
+            incoming,
+            shutdown_signal(log.new(o!("scope" => "shutdown"))),
+        )
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn shutdown_signal(_log: Logger) {
+    tokio::signal::ctrl_c().await.map_or_else(|_| (), |_| ())
+}
+
+#[derive(Debug)]
+struct NamedPipe(pub tokio::net::NamedPipe);
+
+impl Connected for NamedPipe {}
+
+impl AsyncRead for NamedPipe {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for NamedPipe {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}


### PR DESCRIPTION
The Windows named pipe support works analogous to the unix domain
socket on unix platforms. It will be used as our "trusted local path"
when connecting to Avery.