### PR TITLE
✨ Implement user metadata for local sockets/pipes

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -2,7 +2,7 @@
     "nedryland": {
         "branch": "main",
         "repo": "git@github.com:goodbyekansas/nedryland",
-        "rev": "f9dda9d7b49a2aa7379e79368351b1eec38b3ee8",
+        "rev": "78a7d34aa2c8fbd4262e73ee91ed9b797b7cbbc0",
         "type": "git"
     },
     "niv": {

--- a/services/avery/Cargo.lock
+++ b/services/avery/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
  "prost",
  "regex",
  "semver",
- "serde 1.0.124",
+ "serde 1.0.125",
  "sha2",
  "slog",
  "slog-async",
@@ -121,9 +121,11 @@ dependencies = [
  "tonic-middleware",
  "typetag",
  "url",
+ "users",
  "uuid",
  "wasmer",
  "wasmer-wasi",
+ "winapi",
 ]
 
 [[package]]
@@ -153,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
 dependencies = [
  "byteorder",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -244,7 +246,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -323,7 +325,7 @@ version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86badbce14e15f52a45b666b38abe47b204969dd7f8fb7488cb55dd46b361fa6"
 dependencies = [
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -394,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
@@ -500,7 +502,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
 dependencies = [
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -669,7 +671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
 dependencies = [
  "cfg-if 0.1.10",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -853,7 +855,7 @@ checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -929,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "libloading"
@@ -1019,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -1032,11 +1034,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
@@ -1546,9 +1547,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
@@ -1572,14 +1573,14 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1594,7 +1595,7 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -1929,7 +1930,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -2068,7 +2069,7 @@ dependencies = [
  "erased-serde",
  "inventory",
  "lazy_static",
- "serde 1.0.124",
+ "serde 1.0.125",
  "typetag-impl",
 ]
 
@@ -2144,13 +2145,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
- "serde 1.0.124",
+ "serde 1.0.125",
 ]
 
 [[package]]
@@ -2265,7 +2276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b7732a9cab472bd921d5a0c422f45b3d03f62fa2c40a89e0770cef6d47e383e"
 dependencies = [
  "enumset",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_bytes",
  "smallvec",
  "target-lexicon",
@@ -2286,7 +2297,7 @@ dependencies = [
  "gimli 0.22.0",
  "more-asserts",
  "rayon",
- "serde 1.0.124",
+ "serde 1.0.125",
  "smallvec",
  "tracing",
  "wasmer-compiler",
@@ -2318,7 +2329,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -2336,7 +2347,7 @@ dependencies = [
  "bincode",
  "cfg-if 0.1.10",
  "region",
- "serde 1.0.124",
+ "serde 1.0.125",
  "serde_bytes",
  "wasmer-compiler",
  "wasmer-engine",
@@ -2355,7 +2366,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "leb128",
  "libloading",
- "serde 1.0.124",
+ "serde 1.0.125",
  "tempfile",
  "tracing",
  "wasmer-compiler",
@@ -2385,7 +2396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f4ac28c2951cd792c18332f03da523ed06b170f5cf6bb5b1bdd7e36c2a8218"
 dependencies = [
  "cranelift-entity",
- "serde 1.0.124",
+ "serde 1.0.125",
  "thiserror",
 ]
 
@@ -2403,7 +2414,7 @@ dependencies = [
  "memoffset",
  "more-asserts",
  "region",
- "serde 1.0.124",
+ "serde 1.0.125",
  "thiserror",
  "wasmer-types",
  "winapi",
@@ -2420,7 +2431,7 @@ dependencies = [
  "generational-arena",
  "getrandom",
  "libc",
- "serde 1.0.124",
+ "serde 1.0.125",
  "thiserror",
  "time",
  "tracing",

--- a/services/avery/Cargo.toml
+++ b/services/avery/Cargo.toml
@@ -37,6 +37,13 @@ wasmer = "1"
 firm-types = { version = "0.1", registry = "nix" }
 tonic-middleware = { version = "0.1", registry = "nix" }
 
+[target.'cfg(unix)'.dependencies]
+users = "0.11"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
+
 # our own version of tokio 1.3.0 with named pipes
 [patch.crates-io]
 tokio = {  git = "https://github.com/goodbyekansas/tokio.git", branch="named-pipes-1.3.0" }
+

--- a/services/avery/src/lib.rs
+++ b/services/avery/src/lib.rs
@@ -3,6 +3,7 @@ pub mod executor;
 pub mod proxy_registry;
 pub mod registry;
 pub mod runtime;
+mod userinfo;
 
 #[cfg(unix)]
 pub mod unix;

--- a/services/avery/src/proxy_registry.rs
+++ b/services/avery/src/proxy_registry.rs
@@ -10,7 +10,11 @@ use firm_types::{
 use futures::{stream, StreamExt, TryStreamExt};
 use slog::{info, o, warn, Logger};
 use thiserror::Error;
-use tonic::transport::{ClientTlsConfig, Endpoint};
+use tonic::{
+    metadata::KeyAndValueRef,
+    metadata::MetadataMap,
+    transport::{ClientTlsConfig, Endpoint},
+};
 use tonic_middleware::HttpStatusInterceptor;
 use url::Url;
 
@@ -166,6 +170,19 @@ impl ProxyRegistry {
     }
 }
 
+fn request_with_metadata<T>(payload: T, metadata: &MetadataMap) -> tonic::Request<T> {
+    let mut new_request = tonic::Request::new(payload);
+    let meta = new_request.metadata_mut();
+    metadata.iter().for_each(|kv| {
+        match kv {
+            KeyAndValueRef::Ascii(key, value) => meta.append(key, value.clone()),
+            KeyAndValueRef::Binary(key, value) => meta.append_bin(key, value.clone()),
+        };
+    });
+
+    new_request
+}
+
 /// Implementation of Registry as a proxy
 ///
 /// This basically forwards all calls to an internal registry except
@@ -179,23 +196,25 @@ impl Registry for ProxyRegistry {
         firm_types::tonic::Response<firm_types::functions::Functions>,
         firm_types::tonic::Status,
     > {
+        let metadata = request.metadata().clone();
         let payload = request.into_inner();
-        let mut functions = stream::iter(
-            self.connections
-                .iter()
-                .map(|connection| (connection.clone(), payload.clone())),
-        )
-        .then(|(mut connection, payload)| async move {
+        let mut functions = stream::iter(self.connections.iter().map(|connection| {
+            (
+                connection.clone(),
+                request_with_metadata(payload.clone(), &metadata),
+            )
+        }))
+        .then(|(mut connection, request)| async move {
             connection
                 .client
-                .list(tonic::Request::new(payload))
+                .list(request)
                 .await
                 .map(|functions| (connection.name.clone(), functions))
         })
         .chain(
             stream::once(
                 self.internal_registry
-                    .list(tonic::Request::new(payload.clone())),
+                    .list(request_with_metadata(payload.clone(), &metadata)),
             )
             .map(|f| f.map(|functions| (String::from("internal"), functions))),
         )
@@ -306,24 +325,25 @@ impl Registry for ProxyRegistry {
         firm_types::tonic::Response<firm_types::functions::Function>,
         firm_types::tonic::Status,
     > {
+        let metadata = request.metadata().clone();
         let payload = request.into_inner();
 
         let res = stream::iter(
             self.connections
                 .iter()
-                .map(|client| (client.clone(), payload.clone())),
+                .map(|client| (client.clone(), request_with_metadata(payload.clone(), &metadata))),
         )
-        .then(|(mut connection, payload)| async move {
+        .then(|(mut connection, request)| async move {
             connection
                 .client
-                .get(tonic::Request::new(payload))
+                .get(request)
                 .await
                 .map(|functions| (connection.name.clone(), functions))
         })
         .chain(
             stream::once(
                 self.internal_registry
-                    .get(tonic::Request::new(payload.clone())),
+                    .get(request_with_metadata(payload.clone(), &metadata)),
             )
             .map(|f| f.map(|functions| (String::from("internal"), functions))),
         )

--- a/services/avery/src/unix.rs
+++ b/services/avery/src/unix.rs
@@ -1,11 +1,15 @@
 use std::{
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     pin::Pin,
     task::{Context, Poll},
 };
 
 use firm_types::{
     functions::{execution_server::ExecutionServer, registry_server::RegistryServer},
-    tonic::transport::{server::Connected, Server},
+    tonic::{
+        transport::{server::Connected, Server},
+        Request, Status,
+    },
 };
 use futures::{FutureExt, TryFutureExt};
 use slog::{info, o, Logger};
@@ -14,8 +18,9 @@ use tokio::{
     net::UnixListener,
     signal::unix::{signal, SignalKind},
 };
+use users::os::unix::UserExt;
 
-use crate::{executor::ExecutionService, proxy_registry::ProxyRegistry};
+use crate::{executor::ExecutionService, proxy_registry::ProxyRegistry, userinfo::apply_user_info};
 
 pub const INTERNAL_PORT_PATH: &str = "/tmp/avery.sock";
 pub const DEFAULT_RUNTIME_DIR: &str = "/usr/share/avery/runtimes";
@@ -30,15 +35,25 @@ pub async fn create_trap_door(
         let uds = UnixListener::bind(local_socket_path).map_err(|e| e.to_string())?;
 
         async_stream::stream! {
-            while let item = uds.accept().map_ok(|(st, _)| UnixStream(st)).await {
+            while let item = uds.accept().map_ok(|(st, _)| {
+                UnixStream {
+                    stream: st,
+                }
+            }).await {
                 yield item;
             }
         }
     };
 
     let server = Server::builder()
-        .add_service(ExecutionServer::new(execution_service))
-        .add_service(RegistryServer::new(proxy_registry))
+        .add_service(ExecutionServer::with_interceptor(
+            execution_service,
+            inject_user,
+        ))
+        .add_service(RegistryServer::with_interceptor(
+            proxy_registry,
+            inject_user,
+        ))
         .serve_with_incoming_shutdown(
             incoming,
             shutdown_signal(log.new(o!("scope" => "shutdown"))),
@@ -47,6 +62,39 @@ pub async fn create_trap_door(
         .map_err(|e| e.to_string());
     std::fs::remove_file(local_socket_path).unwrap_or(());
     server
+}
+
+fn inject_user(mut req: Request<()>) -> Result<Request<()>, Status> {
+    req.remote_addr()
+        .ok_or_else(|| Status::unauthenticated("Could not find credentials.".to_owned()))
+        .and_then(|val| {
+            match val {
+                // We have previously injected the ID as an Ipv6 address so we know we always get one.
+                // Need to treat Ipv4 as an error case.
+                SocketAddr::V6(ipv6) => {
+                    let uid: u32 = u128::from(*ipv6.ip()) as u32;
+                    let user = users::get_user_by_uid(uid).ok_or_else(|| {
+                        Status::unauthenticated(format!("Failed to find user for id {}", uid))
+                    })?;
+                    apply_user_info(
+                        // Might drop some chars from the users name but we do not care.
+                        user.name().to_string_lossy().to_string(),
+                        user.home_dir(),
+                        req.metadata_mut(),
+                    )
+                    .map_err(|_| {
+                        Status::unauthenticated(
+                            "Failed to insert user metadata in request.".to_owned(),
+                        )
+                    })?;
+
+                    Ok(req)
+                }
+                SocketAddr::V4(_) => Err(Status::unauthenticated(
+                    "Could not find credentials.".to_owned(),
+                )),
+            }
+        })
 }
 
 async fn sig_term() {
@@ -64,9 +112,19 @@ pub async fn shutdown_signal(log: Logger) {
 }
 
 #[derive(Debug)]
-struct UnixStream(pub tokio::net::UnixStream);
+struct UnixStream {
+    stream: tokio::net::UnixStream,
+}
 
-impl Connected for UnixStream {}
+// Hack: Using existing data inside the request to insert an user id (cookie).
+impl Connected for UnixStream {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        self.stream.peer_cred().ok().map(|v| {
+            let encoded_cookie: u128 = v.uid() as u128 | ((v.gid() as u128) << 32);
+            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::from(encoded_cookie), 0, 0, 0))
+        })
+    }
+}
 
 impl AsyncRead for UnixStream {
     fn poll_read(
@@ -74,7 +132,7 @@ impl AsyncRead for UnixStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.0).poll_read(cx, buf)
+        Pin::new(&mut self.stream).poll_read(cx, buf)
     }
 }
 
@@ -84,14 +142,14 @@ impl AsyncWrite for UnixStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.0).poll_write(cx, buf)
+        Pin::new(&mut self.stream).poll_write(cx, buf)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.0).poll_flush(cx)
+        Pin::new(&mut self.stream).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.0).poll_shutdown(cx)
+        Pin::new(&mut self.stream).poll_shutdown(cx)
     }
 }

--- a/services/avery/src/userinfo.rs
+++ b/services/avery/src/userinfo.rs
@@ -1,0 +1,47 @@
+use std::path::{Path, PathBuf};
+
+use firm_types::tonic::{
+    metadata::{errors::InvalidMetadataValue, AsciiMetadataValue, MetadataMap},
+    Request,
+};
+
+pub fn apply_user_info<'a>(
+    user_name: String,
+    home_folder: &Path,
+    metadata: &'a mut MetadataMap,
+) -> Result<&'a MetadataMap, InvalidMetadataValue> {
+    metadata.insert("username", AsciiMetadataValue::from_str(&user_name)?);
+    metadata.insert(
+        "home_folder",
+        AsciiMetadataValue::from_str(&home_folder.to_string_lossy())?,
+    );
+    Ok(metadata)
+}
+
+#[derive(Clone, Debug)]
+pub struct UserInfo {
+    pub username: String,
+    pub home_folder: PathBuf,
+}
+
+pub trait RequestUserInfo {
+    fn get_user_info(&self) -> UserInfo;
+}
+
+impl<T> RequestUserInfo for Request<T> {
+    fn get_user_info(&self) -> UserInfo {
+        UserInfo {
+            username: self
+                .metadata()
+                .get("username")
+                .map(|v| v.to_str().unwrap_or_default().to_owned())
+                .unwrap_or_default(),
+            home_folder: PathBuf::from(
+                self.metadata()
+                    .get("home_folder")
+                    .map(|v| v.to_str().unwrap_or_default())
+                    .unwrap_or_default(),
+            ),
+        }
+    }
+}

--- a/services/avery/src/windows.rs
+++ b/services/avery/src/windows.rs
@@ -1,11 +1,19 @@
 use std::{
+    ffi::OsString,
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
+    os::windows::{ffi::OsStringExt, io::AsRawHandle, raw::HANDLE},
+    path::PathBuf,
     pin::Pin,
+    ptr,
     task::{Context, Poll},
 };
 
 use firm_types::{
     functions::{execution_server::ExecutionServer, registry_server::RegistryServer},
-    tonic::transport::{server::Connected, Server},
+    tonic::{
+        transport::{server::Connected, Server},
+        Request, Status,
+    },
 };
 use futures::TryFutureExt;
 use slog::{o, Logger};
@@ -13,8 +21,20 @@ use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     net::NamedPipeServerBuilder,
 };
+use winapi::{
+    shared::winerror::S_OK,
+    um::{
+        combaseapi::CoTaskMemFree,
+        knownfolders::FOLDERID_Profile,
+        namedpipeapi::ImpersonateNamedPipeClient,
+        securitybaseapi::RevertToSelf,
+        shlobj::SHGetKnownFolderPath,
+        winbase::{lstrlenW, GetUserNameW},
+        winnt::PWSTR,
+    },
+};
 
-use crate::{executor::ExecutionService, proxy_registry::ProxyRegistry};
+use crate::{executor::ExecutionService, proxy_registry::ProxyRegistry, userinfo::apply_user_info};
 
 pub const INTERNAL_PORT_PATH: &str = r#"\\.\pipe\avery"#;
 pub const DEFAULT_RUNTIME_DIR: &str = r#"%PROGRAMDATA%\Avery\runtimes"#;
@@ -39,8 +59,14 @@ pub async fn create_trap_door(
     };
 
     Server::builder()
-        .add_service(ExecutionServer::new(execution_service))
-        .add_service(RegistryServer::new(proxy_registry))
+        .add_service(ExecutionServer::with_interceptor(
+            execution_service,
+            inject_user,
+        ))
+        .add_service(RegistryServer::with_interceptor(
+            proxy_registry,
+            inject_user,
+        ))
         .serve_with_incoming_shutdown(
             incoming,
             shutdown_signal(log.new(o!("scope" => "shutdown"))),
@@ -53,10 +79,88 @@ pub async fn shutdown_signal(_log: Logger) {
     tokio::signal::ctrl_c().await.map_or_else(|_| (), |_| ())
 }
 
+unsafe fn get_home_folder() -> Option<PathBuf> {
+    let mut path_ptr: PWSTR = ptr::null_mut();
+
+    let home_folder = (SHGetKnownFolderPath(&FOLDERID_Profile, 0, ptr::null_mut(), &mut path_ptr)
+        == S_OK)
+        .then(|| {
+            let ostr: OsString = OsStringExt::from_wide(::std::slice::from_raw_parts(
+                path_ptr,
+                lstrlenW(path_ptr) as usize,
+            ));
+            PathBuf::from(ostr)
+        });
+
+    CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+    home_folder
+}
+
+unsafe fn get_user() -> Option<String> {
+    const CAPACITY: usize = 1024;
+    let mut size = CAPACITY as u32;
+    let mut name: [u16; CAPACITY] = [0; CAPACITY];
+    (GetUserNameW(name.as_mut_ptr(), &mut size as *mut u32) != 0)
+        .then(|| String::from_utf16_lossy(&name[..(size as usize) - 1]))
+}
+
+fn inject_user(mut req: Request<()>) -> Result<Request<()>, Status> {
+    req.remote_addr()
+        .ok_or_else(|| Status::unauthenticated("Could not find credentials.".to_owned()))
+        .and_then(|val| {
+            match val {
+                // We have previously injected the ID as an Ipv6 address so we know we always get one.
+                // Need to treat Ipv4 as an error case.
+                SocketAddr::V6(ipv6) => unsafe {
+                    (ImpersonateNamedPipeClient(u128::from(*ipv6.ip()) as HANDLE) != 0)
+                        .then(|| ())
+                        .and_then(|_| {
+                            let res = get_user().and_then(|username| {
+                                get_home_folder().map(|homefolder| (username, homefolder))
+                            });
+
+                            if RevertToSelf() == 0 {
+                                panic!("Failed to undo user impersonation in named pipe. Process has to be restarted.");
+                            }
+
+                            res
+                        })
+                        .ok_or_else(|| {
+                            Status::unauthenticated(
+                                "Failed to determine named pipe user.".to_owned(),
+                            )
+                        })
+                        .and_then(|(user_name, home_folder)| {
+                            apply_user_info(user_name, &home_folder, req.metadata_mut()).map_err(
+                                |_| {
+                                    Status::unauthenticated(
+                                        "Failed to insert user metadata in request.".to_owned(),
+                                    )
+                                },
+                            )?;
+                            Ok(req)
+                        })
+                },
+                SocketAddr::V4(_) => Err(Status::unauthenticated(
+                    "Could not find credentials.".to_owned(),
+                )),
+            }
+        })
+}
+
 #[derive(Debug)]
 struct NamedPipe(pub tokio::net::NamedPipe);
 
-impl Connected for NamedPipe {}
+impl Connected for NamedPipe {
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        Some(SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::from(self.0.as_raw_handle() as u128),
+            0,
+            0,
+            0,
+        )))
+    }
+}
 
 impl AsyncRead for NamedPipe {
     fn poll_read(


### PR DESCRIPTION
This uses peer credentials (https://man7.org/linux/man-pages/man7/unix.7.html)
for unix domain sockets on unix platforms and named pipe
impersonation (https://docs.microsoft.com/en-us/windows/win32/ipc/impersonating-a-named-pipe-client)
on windows platforms.