### PR TITLE
[PIPE-1737] ✨ Add Serialization and Deserialization of tokens

### DIFF
--- a/services/avery/src/config.rs
+++ b/services/avery/src/config.rs
@@ -28,7 +28,7 @@ impl Default for KeyStore {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Hash)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum IdentityProvider {
     Oidc { provider: String },
@@ -217,7 +217,7 @@ client_secret="no"
 
     #[test]
     fn registries() {
-        // Test registries in config, make sure oath_scope is optional
+        // Test registries in config, make sure oauth_scope is optional
         let c = Config::new_with_toml_string(
             r#"
         [[registries]]


### PR DESCRIPTION
This saves the serialized tokens in a file in the Avery-folder for the current user. This
results in the user only having to log in once for the providers that support this caching
mechanism (OIDC is the current example).

It also makes us less likely to hit any
rate-limits since we can use the OAuth2 refresh token instead of launching a new auth flow
every time so win-win.