### PR TITLE
🐛 Fix avery default config file location

### DIFF
--- a/services/avery/src/config.rs
+++ b/services/avery/src/config.rs
@@ -142,13 +142,10 @@ impl Config {
         let current_folder_cfg = Path::new(DEFAULT_CFG_FILE_NAME);
         if current_folder_cfg.exists() {
             c.merge(File::from(current_folder_cfg))?;
-        } else {
-            #[cfg(unix)]
-            {
-                let etc_path = Path::new("/etc/avery").join(DEFAULT_CFG_FILE_NAME);
-                if etc_path.exists() {
-                    c.merge(File::from(etc_path))?;
-                }
+        } else if let Some(user_cfg_path) = crate::system::user_config_path() {
+            let path = user_cfg_path.join(DEFAULT_CFG_FILE_NAME);
+            if path.exists() {
+                c.merge(File::from(path))?;
             }
         }
 

--- a/services/avery/src/unix.rs
+++ b/services/avery/src/unix.rs
@@ -20,6 +20,16 @@ pub fn user() -> Option<String> {
     get_current_username().map(|x| x.to_string_lossy().to_string())
 }
 
+pub fn user_config_path() -> Option<PathBuf> {
+    match std::env::var("XDG_CONFIG_HOME").ok() {
+        Some(p) => Some(PathBuf::from(p)),
+        None => std::env::var("HOME")
+            .ok()
+            .map(|p| PathBuf::from(p).join(".config")),
+    }
+    .map(|p| p.join("avery"))
+}
+
 pub fn user_cache_path() -> Option<PathBuf> {
     match std::env::var("XDG_CACHE_HOME").ok() {
         Some(p) => Some(PathBuf::from(p)),

--- a/services/avery/src/windows.rs
+++ b/services/avery/src/windows.rs
@@ -27,6 +27,12 @@ pub fn user() -> Option<String> {
     unsafe { get_user() }
 }
 
+pub fn user_config_path() -> Option<PathBuf> {
+    std::env::var("LOCALAPPDATA")
+        .ok()
+        .map(|p| PathBuf::from(p).join("avery").join("config"))
+}
+
 pub fn user_cache_path() -> Option<PathBuf> {
     std::env::var("LOCALAPPDATA")
         .ok()


### PR DESCRIPTION
It is a user service, it should not be looking for config files in system-wide
locations. This also adds support for default config file location on Windows.