### PR TITLE
🐛 Only read output once

### DIFF
--- a/services/avery/src/runtime/wasi/process.rs
+++ b/services/avery/src/runtime/wasi/process.rs
@@ -60,6 +60,7 @@ where
                 |_| warn!(logger, "Failed to write \"{}\" to output.", s),
                 |_| (),
             );
+            s.clear();
         }
     }
 }


### PR DESCRIPTION
Need to clear the string buffer between reads