### PR TITLE
✨ 🔒 [PIPE-1697] Add TLS encryption to Lomax and Bendini

### DIFF
--- a/clients/bendini/Cargo.lock
+++ b/clients/bendini/Cargo.lock
@@ -34,6 +34,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-stream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,14 +102,20 @@ dependencies = [
  "async-stream",
  "atty",
  "chrono",
+ "der-parser",
  "firm-types",
  "futures",
+ "http",
  "indicatif",
+ "pem",
  "prost",
  "rand",
  "regex",
  "reqwest",
+ "rustls",
+ "rustls-native-certs",
  "serde",
+ "sha-1",
  "structopt",
  "tempfile",
  "thiserror",
@@ -113,7 +125,9 @@ dependencies = [
  "tower",
  "url",
  "users",
+ "webpki",
  "winapi",
+ "x509-parser",
 ]
 
 [[package]]
@@ -121,6 +135,27 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -206,6 +241,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "der-oid-macro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4cccf60bb98c0fca115a581f894aed0e43fa55bf289fdac5599bec440bb4fd6"
+dependencies = [
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "syn",
+]
+
+[[package]]
+name = "der-parser"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120842c2385dea19347e2f6e31caa5dced5ba8afdfacaac16c59465fdd1168f2"
+dependencies = [
+ "der-oid-macro",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +346,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -353,6 +443,16 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -552,6 +652,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,12 +720,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -651,16 +788,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
+name = "oid-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2508c8f170e55be68508b1113956a760a82684f42022f8834fb16ca198621211"
+dependencies = [
+ "der-parser",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64",
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -782,6 +945,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -909,6 +1078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +1110,12 @@ dependencies = [
  "schannel",
  "security-framework",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -1026,6 +1210,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1243,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1087,6 +1290,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1361,6 +1570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,4 +1793,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "x509-parser"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64abca276c58f8341ddc13fd4bd6ae75993cc669043f5b34813c90f7dff04771"
+dependencies = [
+ "base64",
+ "chrono",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "rustversion",
+ "thiserror",
 ]

--- a/clients/bendini/Cargo.toml
+++ b/clients/bendini/Cargo.toml
@@ -11,15 +11,23 @@ ansi_term = "0.12"
 async-stream = "0.3"
 atty = "0.2"
 chrono = "0.4.19"
+der-parser = "5.1.0"
 futures = "0.3"
+http = "0.2.4"
 indicatif = "0.15"
+pem = "0.8.3"
 prost = "0.7"
 rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11", features = ["rustls-tls"], default-features = false }
+rustls-native-certs = "0.5.0"
+rustls = "0.19.1"
 serde = { version = "1", features = ["derive"] }
+sha-1 = "0.9.6"
 structopt = "0.3"
 thiserror = "1"
+webpki = "0.21.0"
+x509-parser = "0.9.2"
 
 # use `=` here to match our fork belowf
 tokio = { version = "=1.4.0", features = ["rt-multi-thread", "macros", "net"] }

--- a/clients/bendini/src/interactive_cert_verifier.rs
+++ b/clients/bendini/src/interactive_cert_verifier.rs
@@ -1,0 +1,343 @@
+use std::{
+    fmt::Debug,
+    fs::OpenOptions,
+    io::{BufRead, BufReader, Write},
+    path::{Path, PathBuf},
+    sync::RwLock,
+};
+
+use rustls::{Certificate, RootCertStore, ServerCertVerifier, WebPKIVerifier};
+use sha1::{Digest, Sha1};
+
+pub struct InteractiveCertVerifier {
+    inner: WebPKIVerifier,
+    cert_bundle: PathBuf,
+    root_store: RwLock<RootCertStore>,
+    root_store_certs: RwLock<Vec<Certificate>>,
+}
+
+impl Debug for InteractiveCertVerifier {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        writeln!(
+            fmt,
+            "InteractiveCertVerifier saving accepted certs @ {}",
+            self.cert_bundle.display()
+        )
+    }
+}
+
+impl InteractiveCertVerifier {
+    pub fn new(root_directory: &Path) -> Result<Self, std::io::Error> {
+        let mut icv = Self {
+            inner: WebPKIVerifier::new(),
+            cert_bundle: root_directory.join("cert-bundle.pem"),
+            root_store: RwLock::new(RootCertStore::empty()),
+            root_store_certs: RwLock::new(Vec::new()),
+        };
+
+        if icv.cert_bundle.exists() {
+            // parse certificates from bundle file
+            // we store both the full x509 certificate
+            // and the webpki subset needed for validation. This is
+            // since we want to be able to write out a complete PEM cert
+            // chain again
+            let root_store_certs = std::fs::OpenOptions::new()
+                .read(true)
+                .open(&icv.cert_bundle)
+                .map(BufReader::new)
+                .and_then(|mut rdr| {
+                    rustls::internal::pemfile::certs(&mut rdr)
+                        .map_err(|_| std::io::ErrorKind::InvalidData.into())
+                })?;
+
+            let mut root_store = RootCertStore::empty();
+            root_store_certs
+                .iter()
+                .try_for_each(|cert| root_store.add(cert))
+                .map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))?;
+
+            icv.root_store_certs = RwLock::new(root_store_certs);
+            icv.root_store = RwLock::new(root_store);
+        }
+
+        Ok(icv)
+    }
+
+    fn get_alt_names_and_fingerprint(
+        presented_certs: &[Certificate],
+    ) -> Result<(String, String), rustls::TLSError> {
+        presented_certs
+            .first()
+            .ok_or(rustls::TLSError::NoCertificatesPresented)
+            .and_then(|c| {
+                x509_parser::parse_x509_certificate(c.as_ref())
+                    .map_err(|e| {
+                        rustls::TLSError::General(format!(
+                            "Failed to parse x509 certificate: {}",
+                            e
+                        ))
+                    })
+                    .map(|(_, parsed)| (Sha1::digest(c.as_ref()), parsed))
+            })
+            .and_then(|(fingerprint, parsed)| {
+                parsed
+                    .extensions()
+                    .get(&der_parser::oid!(2.5.29 .17))
+                    .ok_or_else(|| {
+                        rustls::TLSError::General(
+                            "Certificate does not contain SubjectAlternativeName extension"
+                                .to_owned(),
+                        )
+                    })
+                    .and_then(|alt_names_ext| match alt_names_ext.parsed_extension() {
+                        x509_parser::extensions::ParsedExtension::SubjectAlternativeName(names) => {
+                            Ok(names
+                                .general_names
+                                .iter()
+                                .map(|n| match n {
+                                    x509_parser::extensions::GeneralName::OtherName(_, _) => {
+                                        "other".to_owned()
+                                    }
+                                    x509_parser::extensions::GeneralName::RFC822Name(n) => {
+                                        n.to_string()
+                                    }
+                                    x509_parser::extensions::GeneralName::DNSName(n) => {
+                                        n.to_string()
+                                    }
+                                    x509_parser::extensions::GeneralName::DirectoryName(n) => {
+                                        n.to_string()
+                                    }
+                                    x509_parser::extensions::GeneralName::URI(_) => {
+                                        "uri".to_owned()
+                                    }
+                                    x509_parser::extensions::GeneralName::IPAddress(_) => {
+                                        "ip".to_owned()
+                                    }
+                                    x509_parser::extensions::GeneralName::RegisteredID(_) => {
+                                        "id".to_owned()
+                                    }
+                                })
+                                .collect::<Vec<String>>()
+                                .join(", "))
+                        }
+                        _ => Err(rustls::TLSError::General(
+                            "SubjectAlternativeName extension has the wrong type!?".to_owned(),
+                        )),
+                    })
+                    .map(|alt_names| {
+                        (
+                            format!("{:X}", fingerprint)
+                                .chars()
+                                .enumerate()
+                                .flat_map(|(i, c)| {
+                                    if i != 0 && i % 2 == 0 {
+                                        Some(':')
+                                    } else {
+                                        None
+                                    }
+                                    .into_iter()
+                                    .chain(std::iter::once(c))
+                                })
+                                .collect::<String>(),
+                            alt_names,
+                        )
+                    })
+            })
+    }
+
+    fn add_certs_to_root(&self, presented_certs: &[Certificate]) -> Result<(), rustls::TLSError> {
+        self.root_store_certs
+            .write()
+            .map_err(|e| {
+                rustls::TLSError::General(format!(
+                    "Failed to acquire write lock to add cert to root: {}",
+                    e
+                ))
+            })?
+            .extend_from_slice(presented_certs);
+
+        self.root_store
+            .try_write()
+            .map_err(|e| {
+                rustls::TLSError::General(format!(
+                    "Failed to acquire write lock to add cert to root store: {}",
+                    e
+                ))
+            })
+            .and_then(|mut root_store| {
+                presented_certs
+                    .iter()
+                    .try_for_each(|c| root_store.add(c).map_err(rustls::TLSError::WebPKIError))
+            })
+    }
+
+    fn merge_root_from(&self, root_store: &RootCertStore) -> Result<(), rustls::TLSError> {
+        // note that since these are not added to `root_store_certs`
+        // these certs will not (should not and can not) be saved to disk.
+        self.root_store
+            .write()
+            .map_err(|e| {
+                rustls::TLSError::General(format!(
+                    "Failed to acquire write lock to add cert to root store: {}",
+                    e
+                ))
+            })
+            .map(|mut store| store.roots.extend_from_slice(&root_store.roots))
+    }
+
+    fn save_roots(&self) -> Result<(), rustls::TLSError> {
+        self.root_store_certs
+            .read()
+            .map_err(|e| {
+                rustls::TLSError::General(format!(
+                    "Failed to acquire read lock to save certs to file: {}",
+                    e
+                ))
+            })
+            .and_then(|root_store_certs| {
+                OpenOptions::new()
+                    .append(true)
+                    .create(true)
+                    .open(&self.cert_bundle)
+                    .map_err(|e| {
+                        rustls::TLSError::General(format!(
+                            "Failed to open cert bundle file at {}: {}",
+                            self.cert_bundle.display(),
+                            e
+                        ))
+                    })
+                    .and_then(|mut f| {
+                        f.write(
+                            pem::encode_many(
+                                root_store_certs
+                                    .iter()
+                                    .map(|c| pem::Pem {
+                                        tag: String::from("CERTIFICATE"),
+                                        contents: c.as_ref().to_vec(),
+                                    })
+                                    .collect::<Vec<pem::Pem>>()
+                                    .as_slice(),
+                            )
+                            .as_bytes(),
+                        )
+                        .map(|_| ())
+                        .map_err(|e| {
+                            rustls::TLSError::General(format!(
+                                "Failed to write cert bundle file at {}: {}",
+                                self.cert_bundle.display(),
+                                e
+                            ))
+                        })
+                    })
+            })
+    }
+}
+
+impl ServerCertVerifier for InteractiveCertVerifier {
+    fn verify_server_cert(
+        &self,
+        roots: &RootCertStore,
+        presented_certs: &[Certificate],
+        dns_name: webpki::DNSNameRef,
+        ocsp_response: &[u8],
+    ) -> std::result::Result<rustls::ServerCertVerified, rustls::TLSError> {
+        self.merge_root_from(roots)?;
+        self.root_store
+            .read()
+            .map_err(|e| {
+                rustls::TLSError::General(format!(
+                    "Failed to acquire read lock for root cert store: {}",
+                    e
+                ))
+            })
+            .and_then(|roots| {
+                self.inner
+                    .verify_server_cert(&roots, presented_certs, dns_name, ocsp_response)
+            })
+            .or_else(|e| {
+                if let rustls::TLSError::WebPKIError(webpki::Error::UnknownIssuer) = e {
+                    let (fingerprint, alt_names) =
+                        Self::get_alt_names_and_fingerprint(presented_certs)
+                            .unwrap_or_else(|e| (String::new(), format!("<unknown: {}>", e)));
+
+                    println!(
+                        "{}",
+                        warn!(
+                            "Host \"{}\" is using a self-signed certificate.",
+                            AsRef::<str>::as_ref(&dns_name.to_owned())
+                        )
+                    );
+                    println!(
+                        "The host identifies as \"{}\" [{}].",
+                        // An error to parse alt name extension from the cert is
+                        // not really critical but it will hopefully look intimidating
+                        // enough to the user that they will do the right thing
+                        ansi_term::Style::new().bold().paint(alt_names),
+                        fingerprint
+                    );
+                    print!("Do you want to continue? [y(es)/n(o)/S(ave)] ");
+                    let _ = std::io::stdout().flush(); // don't really care if we fail to flush
+
+                    // read the user answer and assume "no" if we for
+                    // some reason cannot read the answer
+                    let stdin = std::io::stdin();
+                    let line = stdin
+                        .lock()
+                        .lines()
+                        .next()
+                        .unwrap_or_else(|| Ok("n".to_owned()))
+                        .unwrap_or_else(|_| "n".to_owned());
+
+                    if line.to_lowercase() == "s"
+                        || line.to_lowercase() == "save"
+                        || line.is_empty()
+                    {
+                        self.add_certs_to_root(presented_certs)?;
+                        self.root_store
+                            .read()
+                            .map_err(|e| {
+                                rustls::TLSError::General(format!(
+                                    "Failed to acquire read lock for root cert store: {}",
+                                    e
+                                ))
+                            })
+                            .and_then(|root| {
+                                self.inner
+                                    .verify_server_cert(
+                                        &root,
+                                        presented_certs,
+                                        dns_name,
+                                        ocsp_response,
+                                    )
+                                    .and_then(|r| {
+                                        self.save_roots()?;
+                                        Ok(r)
+                                    })
+                            })
+                    } else if line.to_lowercase() == "y" || line.to_lowercase() == "yes" {
+                        self.add_certs_to_root(presented_certs)?;
+                        self.root_store
+                            .read()
+                            .map_err(|e| {
+                                rustls::TLSError::General(format!(
+                                    "Failed to acquire read lock for root cert store: {}",
+                                    e
+                                ))
+                            })
+                            .and_then(|root| {
+                                self.inner.verify_server_cert(
+                                    &root,
+                                    presented_certs,
+                                    dns_name,
+                                    ocsp_response,
+                                )
+                            })
+                    } else {
+                        Err(e)
+                    }
+                } else {
+                    Err(e)
+                }
+            })
+    }
+}

--- a/services/lomax/Cargo.lock
+++ b/services/lomax/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
 name = "lomax"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "config",
  "firm-types",
  "futures",
@@ -570,12 +571,17 @@ dependencies = [
  "http",
  "hyper",
  "jsonwebtoken",
+ "libc",
+ "pem",
+ "rcgen",
+ "rustls",
  "serde 1.0.125",
  "slog",
  "slog-async",
  "slog-term",
  "structopt",
  "tokio",
+ "tokio-rustls",
  "tower",
 ]
 
@@ -864,6 +870,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b4fc1b81d685fcd442a86da2e2c829d9e353142633a8159f42bf28e7e94428"
+dependencies = [
+ "chrono",
+ "pem",
+ "ring",
+ "yasna",
 ]
 
 [[package]]
@@ -1601,4 +1619,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yasna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+dependencies = [
+ "chrono",
 ]

--- a/services/lomax/Cargo.toml
+++ b/services/lomax/Cargo.toml
@@ -5,17 +5,23 @@ authors = ["GBK Pipeline Team <pipeline@goodbyekansas.com>"]
 edition = "2018"
 
 [dependencies]
+async-stream = "0.3.1"
 config = "0.11.0"
 futures = "0.3.14"
 hostname = "0.3.1"
 http = "0.2.4"
 hyper = { version = "0.14.7", features = ["full"] }
+libc = "0.2.94"
+pem = "0.8.3"
+rcgen =  { version = "0.8.11", features = ["pem"] }
+rustls = "0.19.0"
 serde = { version = "1.0.125", features = ["derive"] }
 slog = "2.7.0"
 slog-async = "2.6.0"
 slog-term = "2.8.0"
 structopt = "0.3.21"
 tokio = { version = "=1.4.0", features = ["rt-multi-thread", "macros", "signal"] }
+tokio-rustls = "0.22"
 tower = "0.4.7"
 firm-types = { version = "0.1", registry = "nix" }
 jsonwebtoken = "7.2.0"

--- a/services/lomax/src/config.rs
+++ b/services/lomax/src/config.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    convert::TryFrom,
+    path::{Path, PathBuf},
+};
 
 use config::{ConfigError, Environment, File};
 use serde::Deserialize;
@@ -7,10 +10,63 @@ fn default_port() -> u16 {
     1939u16
 }
 
+fn create_self_signed_certificate_default() -> bool {
+    true
+}
+
+fn default_user_and_group() -> String {
+    String::from("firm")
+}
+
+#[derive(Deserialize)]
+struct MaybeCertificateLocations {
+    #[serde(default)]
+    pub certificate_location: Option<PathBuf>,
+
+    #[serde(default)]
+    pub certificate_key_location: Option<PathBuf>,
+}
+
+#[derive(Deserialize)]
+#[serde(try_from = "MaybeCertificateLocations")]
+pub struct CertificateLocations {
+    pub cert: PathBuf,
+    pub key: PathBuf,
+}
+
+impl TryFrom<MaybeCertificateLocations> for CertificateLocations {
+    type Error = &'static str;
+
+    fn try_from(value: MaybeCertificateLocations) -> Result<Self, Self::Error> {
+        Ok(Self {
+            cert: value
+                .certificate_location
+                .or_else(|| crate::system::get_lomax_cfg_dir().map(|p| p.join("cert.pem")))
+                .ok_or("Failed to determine lomax config directory.")?,
+            key: value
+                .certificate_key_location
+                .or_else(|| crate::system::get_lomax_cfg_dir().map(|p| p.join("key.pem")))
+                .ok_or("Failed to determine lomax config directory.")?,
+        })
+    }
+}
+
 #[derive(Deserialize)]
 pub struct Config {
     #[serde(default = "default_port")]
     pub port: u16,
+
+    #[serde(flatten)]
+    pub certificate_locations: CertificateLocations,
+
+    #[serde(default = "create_self_signed_certificate_default")]
+    pub create_self_signed_certificate: bool,
+
+    #[serde(default = "default_user_and_group")]
+    pub user: String,
+
+    #[serde(default = "default_user_and_group")]
+    pub group: String,
 }
 
 const DEFAULT_CFG_FILE_NAME: &str = "lomax.toml";
@@ -24,23 +80,11 @@ impl Config {
         let current_folder_cfg = Path::new(DEFAULT_CFG_FILE_NAME);
         if current_folder_cfg.exists() {
             c.merge(File::from(current_folder_cfg))?;
-        } else {
-            #[cfg(unix)]
-            {
-                let etc_path = Path::new("/etc/lomax").join(DEFAULT_CFG_FILE_NAME);
-                if etc_path.exists() {
-                    c.merge(File::from(etc_path))?;
-                }
-            }
-            #[cfg(windows)]
-            {
-                if let Some(path) = std::env::var_os("PROGRAMDATA")
-                    .map(|appdata| Path::new(&appdata).join(DEFAULT_CFG_FILE_NAME))
-                {
-                    if path.exists() {
-                        c.merge(File::from(path))?;
-                    }
-                }
+        } else if let Some(etc_path) =
+            crate::system::get_lomax_cfg_dir().map(|p| p.join(DEFAULT_CFG_FILE_NAME))
+        {
+            if etc_path.exists() {
+                c.merge(File::from(etc_path))?;
             }
         }
 

--- a/services/lomax/src/tls.rs
+++ b/services/lomax/src/tls.rs
@@ -1,0 +1,138 @@
+use std::{
+    fs::File, io, io::BufReader, io::Read, net::Ipv6Addr, net::SocketAddr, net::SocketAddrV6,
+    path::Path, pin::Pin, sync::Arc, task::Context, task::Poll,
+};
+
+use futures::{Stream, TryFutureExt};
+use rustls::ServerConfig;
+use slog::{info, o, warn, Logger};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::{server::TlsStream, TlsAcceptor as TlsAcceptorTokio};
+
+pub fn get_tls_config(cert_file: &Path, key_file: &Path) -> Result<ServerConfig, String> {
+    File::open(cert_file)
+        .map_err(|e| {
+            format!(
+                "Failed to open certificates file \"{}\": {}",
+                cert_file.display(),
+                e
+            )
+        })
+        .map(BufReader::new)
+        .and_then(|mut reader| {
+            let mut data = Vec::new();
+            reader.read_to_end(&mut data).map_err(|e| {
+                format!(
+                    "Failed to read certificates file \"{}\": {}",
+                    cert_file.display(),
+                    e
+                )
+            })?;
+
+            let certs = pem::parse_many(data);
+
+            if certs.is_empty() {
+                Err(format!(
+                    "Certificates file \"{}\" contained zero valid certificates.",
+                    cert_file.display()
+                ))
+            } else {
+                Ok(certs
+                    .into_iter()
+                    .map(|cert| rustls::Certificate(cert.contents))
+                    .collect())
+            }
+        })
+        .and_then(|certs| {
+            File::open(key_file)
+                .map_err(|e| {
+                    format!(
+                        "Failed to open private key file \"{}\": {}",
+                        key_file.display(),
+                        e
+                    )
+                })
+                .map(|key_file| (certs, BufReader::new(key_file)))
+        })
+        .and_then(|(certs, mut key_reader)| {
+            let mut data = Vec::new();
+            key_reader.read_to_end(&mut data).map_err(|e| {
+                format!(
+                    "Failed to read private key file \"{}\": {}",
+                    key_file.display(),
+                    e
+                )
+            })?;
+
+            pem::parse(data)
+                .map_err(|e| {
+                    format!(
+                        "Failed to parse private key file \"{}\": {}",
+                        key_file.display(),
+                        e
+                    )
+                })
+                .map(|private_key| (certs, rustls::PrivateKey(private_key.contents)))
+        })
+        .and_then(|(certs, private_key)| {
+            let mut cfg = ServerConfig::new(rustls::NoClientAuth::new());
+            cfg.set_single_cert(certs, private_key)
+                .map_err(|e| format!("Failed to set server certificates: {}", e))?;
+            cfg.set_protocols(&[b"h2".to_vec()]);
+            Ok(cfg)
+        })
+}
+
+pub struct TlsAcceptor<'a> {
+    acceptor: Pin<Box<dyn Stream<Item = Result<TlsStream<TcpStream>, io::Error>> + 'a>>,
+}
+
+impl<'a> TlsAcceptor<'a> {
+    pub async fn new(
+        config: ServerConfig,
+        port: u16,
+        log: Logger,
+    ) -> Result<TlsAcceptor<'a>, String> {
+        let addr = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0),
+            port,
+            0,
+            0,
+        ));
+        let tcp = TcpListener::bind(&addr)
+            .await
+            .map_err(|e| format!("Failed to bind TCP listener: {}", e))?;
+        let acceptor = TlsAcceptorTokio::from(Arc::new(config));
+
+        info!(log, "Listening for requests on port {}", addr.port());
+
+        Ok(Self {
+            acceptor: Box::pin(async_stream::stream! {
+                loop {
+                    match tcp.accept().map_err(|e| (e, log.new(o!()))).and_then(|(socket, peer)| {
+                        let peer_addr = peer.to_string();
+                        acceptor.accept(socket).map_err(|e| (e, log.new(o!("peer" => peer_addr))))
+                    }).await {
+                        Ok(conn) => { yield Ok(conn); },
+                        Err((e, log)) => {
+                            warn!(log, "Client connection error: {}", e);
+                            continue;
+                        }
+                    }
+                }
+            }),
+        })
+    }
+}
+
+impl hyper::server::accept::Accept for TlsAcceptor<'_> {
+    type Conn = TlsStream<TcpStream>;
+    type Error = io::Error;
+
+    fn poll_accept(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        Pin::new(&mut self.acceptor).poll_next(cx)
+    }
+}

--- a/services/lomax/src/windows.rs
+++ b/services/lomax/src/windows.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use futures::TryFutureExt;
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -7,6 +9,14 @@ pub async fn shutdown_signal(_log: slog::Logger) {
 
 pub fn get_local_socket(username: &str) -> String {
     format!(r#"windows://./pipe/avery-{username}"#, username = username)
+}
+
+pub fn get_lomax_cfg_dir() -> Option<PathBuf> {
+    std::env::var_os("PROGRAMDATA").map(|appdata| PathBuf::from(&appdata))
+}
+
+pub fn drop_privileges(_: &str, _: &str) -> Result<(), String> {
+    Ok(())
 }
 
 pub struct NamedPipe(tokio::net::NamedPipe);


### PR DESCRIPTION
Lomax can create self-signed certificates if needed and Bendini will prompt users for
accepting (and optionally saving) self-signed certificates.

Example Bendini output:

    Host "localhost" is using a self-signed certificate
    The host identifies as "imac, localhost" [A7:89:A2:07:15:97:2A:4D:3A:3C:57:C2:37:40:88:78:A7:A6:18:B5].
    Do you want to continue? [y(es)/n(o)/S(ave)] y