### PR TITLE
⚡ Add a global config to Avery

### DIFF
--- a/services/avery/.envrc
+++ b/services/avery/.envrc
@@ -1,3 +1,3 @@
-if [ -z "$IN_NIX_SHELL"]; then
+if [ -z "$IN_NIX_SHELL" ]; then
     use nix ../../shell.nix -A avery
 fi

--- a/services/avery/src/config.rs
+++ b/services/avery/src/config.rs
@@ -139,13 +139,25 @@ impl Config {
         let mut c = config::Config::new();
 
         // try some default config file locations
+
         let current_folder_cfg = Path::new(DEFAULT_CFG_FILE_NAME);
         if current_folder_cfg.exists() {
             c.merge(File::from(current_folder_cfg))?;
-        } else if let Some(user_cfg_path) = crate::system::user_config_path() {
-            let path = user_cfg_path.join(DEFAULT_CFG_FILE_NAME);
-            if path.exists() {
-                c.merge(File::from(path))?;
+        } else {
+            // first, a global config file
+            if let Some(global_cfg_path) = crate::system::global_config_path() {
+                let path = global_cfg_path.join(DEFAULT_CFG_FILE_NAME);
+                if path.exists() {
+                    c.merge(File::from(path))?;
+                }
+            }
+
+            // overridden by a local one
+            if let Some(user_cfg_path) = crate::system::user_config_path() {
+                let path = user_cfg_path.join(DEFAULT_CFG_FILE_NAME);
+                if path.exists() {
+                    c.merge(File::from(path))?;
+                }
             }
         }
 

--- a/services/avery/src/unix.rs
+++ b/services/avery/src/unix.rs
@@ -21,6 +21,10 @@ pub fn user() -> Option<String> {
     get_current_username().map(|x| x.to_string_lossy().to_string())
 }
 
+pub fn global_config_path() -> Option<PathBuf> {
+    Some(PathBuf::from("/etc/avery"))
+}
+
 pub fn user_config_path() -> Option<PathBuf> {
     match std::env::var("XDG_CONFIG_HOME").ok() {
         Some(p) => Some(PathBuf::from(p)),

--- a/services/avery/src/windows.rs
+++ b/services/avery/src/windows.rs
@@ -27,6 +27,10 @@ pub fn user() -> Option<String> {
     unsafe { get_user() }
 }
 
+pub fn global_config_path() -> Option<PathBuf> {
+    std::env::var_os("PROGRAMDATA").map(|appdata| PathBuf::from(&appdata).join("avery"))
+}
+
 pub fn user_config_path() -> Option<PathBuf> {
     std::env::var("LOCALAPPDATA")
         .ok()

--- a/services/lomax/src/windows.rs
+++ b/services/lomax/src/windows.rs
@@ -10,7 +10,7 @@ pub async fn shutdown_signal(_log: slog::Logger) {
 }
 
 pub fn get_lomax_cfg_dir() -> Option<PathBuf> {
-    std::env::var_os("PROGRAMDATA").map(|appdata| PathBuf::from(&appdata))
+    std::env::var_os("PROGRAMDATA").map(|appdata| PathBuf::from(&appdata).join("lomax"))
 }
 
 pub fn drop_privileges(_: &str, _: &str) -> Result<(), String> {


### PR DESCRIPTION
Avery now starts by reading a system-wide config file if it exists. The
settings are then overridden by a per-user config located in the users
home folder.

Also fix a broken config path for windows in Lomax.