### PR TITLE
⚡ Re-set group of Avery socket in Lomax

### DIFF
--- a/services/lomax/Cargo.lock
+++ b/services/lomax/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "http",
  "hyper",
  "jsonwebtoken",
+ "lazy_static",
  "libc",
  "pem",
  "rcgen",

--- a/services/lomax/Cargo.toml
+++ b/services/lomax/Cargo.toml
@@ -26,6 +26,7 @@ tokio-rustls = "0.22"
 tower = "0.4.7"
 firm-types = { version = "0.1", registry = "nix" }
 jsonwebtoken = "7.2.0"
+lazy_static = "1"
 
 # our own version of tokio 1.4.0 with named pipes
 [patch.crates-io]


### PR DESCRIPTION
Change socket file permission for Unix to match the group Lomax is
running as. Note that this is somewhat questionable from a security
perspective but it is better than all users being able to read/write
to/from eachothers sockets.