### PR TITLE
✨ 📚 Add changelogs to firm and components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
@@ -9,3 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - generated documentation for functions, can be customized in the project config under
   `docs.function` with the keys `css` and `jinja` pointing to such files.
+- Extension for markdown to be used for changelogs and such.
+- Shell to work with changelogs and github releases called `release`.
+
+## [1.0.0] - 2021-07-03
+### Packages
+- avery: 1.0.0
+- bendini: 1.0.0
+- firmRust: 1.0.0
+- firmTypes-python: 1.0.0
+- firmTypes-rust-withServices: 1.0.0
+- firmTypes-rust-withoutServices: 1.0.0
+- lomax: 1.0.0
+- quinn: 1.0.0
+- tonicMiddleware: 1.0.0

--- a/clients/bendini/CHANGELOG.md
+++ b/clients/bendini/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Command for listing functions.
+- Command for executing functions.
+- Command for listing runtimes.
+- Command for list auth requests.
+- Command for approving auth requests.

--- a/extensions/shells/release.nix
+++ b/extensions/shells/release.nix
@@ -1,0 +1,112 @@
+{ base, mkShell, linkFarm, python38, lib, components, fetchFromGitHub, github-release, avery, bendini }:
+let
+  components' = components { inherit (base) callFile callFunction; };
+  allChangelogs =
+    let
+      toList = set: if set ? changelog then set else (builtins.map toList (builtins.attrValues set));
+      # This is a bit messy because:
+      # 1. We have nested components
+      # 2. We have "internal" components, without changelogs
+      # 3. We have components that share a changelog
+      allComponentChangelogs = (lib.flatten
+        (builtins.map
+          toList
+          (builtins.attrValues
+            (lib.filterAttrsRecursive
+              (n: v: v != null)
+              (lib.mapAttrsRecursiveCond
+                (attr: !(attr ? isNedrylandComponent))
+                (
+                  names: comp:
+                    if comp ? path && (builtins.readDir (builtins.dirOf comp.path)) ? "CHANGELOG.md" then
+                      { component = builtins.concatStringsSep "-" names; changelog = (builtins.dirOf comp.path) + /CHANGELOG.md; }
+                    else null
+                )
+                components')))));
+      uniqueChangelogs =
+        lib.mapAttrsToList
+          (changelog: component: { name = component; path = changelog; })
+          (builtins.foldl'
+            (acc: cur:
+              if acc ? "${cur.changelog}" then
+                acc // { "${cur.changelog}" = "${acc."${cur.changelog}"}, ${cur.component}"; }
+              else
+                acc // { "${cur.changelog}" = cur.component; }
+            )
+            { }
+            (builtins.trace allComponentChangelogs allComponentChangelogs));
+    in
+    linkFarm
+      "firm-changelogs"
+      uniqueChangelogs;
+in
+mkShell {
+  buildInputs = [ python38 python38.pkgs.keepachangelog github-release ];
+  inherit allChangelogs;
+  shellHook = ''
+    updateChangelogs() {
+      if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+        echo "This tool updates the changelogs for: $(ls -m $allChangelogs | head)."
+        echo
+        echo "It will prompt you for adding version number to unreleased sections (with a suggestion)."
+        echo "Then it will update the main changelog in $FIRM_CHANGELOG and add the changes for the components."
+        echo "For example, if avery has:"
+        echo -e "\033[1;94m  ### Added"
+        echo "  -shiny new feautre"
+        echo -e "  -other cool thing\033[0m"
+        echo "Then the main changelog will get"
+        echo -e "\033[1;94m  ### Added"
+        echo "  -avery: shiny new feature"
+        echo -e "  -avery: other cool thing\033[0m"
+        echo "The main changelog will also get a ###Packages header with the version of each component."
+      else
+        python ${./release/changelog.py} release --changelogs ${allChangelogs}
+      fi
+    }
+
+    makeRelease() {
+        git checkout main
+        git pull
+        version=$(python ${./release/changelog.py} version)
+        description=$(python ${./release/changelog.py} description)
+        old_tags=$(git tag)
+        if [[ "$version" =~ $old_tags ]]; then
+          echo "$version is already tagged"
+        else
+          git tag -a "$version" -m "🔖 Firm $version"
+          git push origin "$version"
+        fi
+        if [ -z "$GITHUB_TOKEN" ]; then
+          if [ -n "$1" ]; then
+            github_token="--security-token \"$1\""
+          else
+            echo "No access token found, can not make a github release remotely!"
+            exit 1
+          fi
+        fi
+        github-release release --tag "$version" --description "$description" "$github_token"
+    }
+
+    export GITHUB_USER="goodbyekansas"
+    export GITHUB_REPO="firm"
+    FIRM_CHANGELOG="$(git rev-parse --show-toplevel)/CHANGELOG.md"
+    export FIRM_CHANGELOG
+
+    echo -e "🚀 \033[1mWelcome to the release shell!\033[0m"
+    echo "The following tools are available in this shell:"
+    echo
+    echo -e "\033[1;96mupdateChangelogs\033[0m"
+    echo "  Updates and gathers all changelogs for all components and put them in the main CHANGELOG.md."
+    echo "  Use updateChangelogs --help for more info."
+    echo
+    echo -e "\033[1;96mmakeRelease\033[0m <access token>"
+    echo "  Creates a tag at the current commit on main, pushes it and makes a github release."
+    echo '  Requires a personal access token to be entered or $GITHUB_TOKEN to be set'
+    echo
+    echo -e "\033[1;96mgithub-release\033[0m"
+    echo "  For manually working with github releases from the command line (this is used internally by makeRelease)."
+    echo "  GITHUB_USER and GITHUB_REPO has been set so --user and --repo arguments are not necessary."
+    echo "  see https://github.com/github-release/github-release/tree/$(github-release --version | sed 's/^.* \(.*\)$/\1/') for more info"
+
+  '';
+}

--- a/extensions/shells/release/changelog.py
+++ b/extensions/shells/release/changelog.py
@@ -1,0 +1,155 @@
+""" Script to work with changelogs in firm"""
+import argparse
+import os
+import pprint
+import re
+import sys
+from functools import partial, reduce
+from typing import Dict, List, Tuple, Union
+
+import keepachangelog  # type: ignore # pylint: disable=import-error
+import keepachangelog._versioning as versioning  # type: ignore # pylint: disable=import-error
+
+# Turn on ANSI colors on windows
+if os.name == "nt":
+    os.system("color")
+
+
+CHANGELOG = os.environ.get("FIRM_CHANGELOG", "file-not-found")
+
+
+def padded_version(version: Union[Tuple[str, dict], str]) -> str:
+    """ 3 digit pad semantic versions so they can be compared as strings safely"""
+    if isinstance(version, str):
+        sem_ver: Dict[str, Union[str, int]] = {}
+        version_data, _, sem_ver["buildmetadata"] = version.partition("+")
+        version_data, _, sem_ver["prerelease"] = version_data.partition("-")
+        sem_ver["major"], sem_ver["minor"], sem_ver["patch"] = map(
+            int, version_data.split(".")
+        )
+    else:
+        sem_ver = version[1]["metadata"]["semantic_version"]
+    sem_ver["prerelease"] = sem_ver["prerelease"] or ""
+    sem_ver["buildmetadata"] = sem_ver["buildmetadata"] or ""
+    return "{major:03}.{minor:03}.{patch:03}.{prerelease}.{buildmetadata}".format(
+        **sem_ver
+    )  # type: ignore
+
+
+def find_latest(versions: dict) -> Tuple[str, dict]:
+    """ Find the latest version (by semantic version) of a set of versions"""
+    return sorted(
+        filter(lambda x: x[0] != "unreleased", versions.items()), key=padded_version
+    )[-1]
+
+
+def get_new_version(changelog: dict) -> str:
+    """ Guess the next version number and ask for correction """
+    latest = find_latest(changelog)
+    new_version = versioning.guess_unreleased_version(
+        changelog, latest[1]["metadata"]["semantic_version"]
+    )
+    print(f"Suggested version for these changes are: {new_version}.")
+    return input("If this is incorrect input a new version here:") or new_version
+
+
+def check_component(
+    released: List[Tuple[str, str]], folder: str, component: str
+) -> Tuple[str, str, dict]:
+    """ Check if a component has a new version since the last firm release """
+    _, version = next(filter(lambda p: p[0] == component, released), (None, "0.0.0"))
+    changelog_file = os.path.join(folder, component)
+    component_changelog = keepachangelog.to_dict(changelog_file, show_unreleased=True)
+    latest = find_latest(component_changelog)
+    if list(component_changelog.get("unreleased", {}).keys()) != ["metadata"]:
+        print(f"\033[95m{component}\033[0m has unreleased changes since {version}:")
+        unreleased = component_changelog.get("unreleased")
+        unreleased.pop("metadata")
+        print(re.sub(r"[\{\}\[\]]", "", pprint.pformat(unreleased, indent=2)))
+        new_version = get_new_version(component_changelog)
+        keepachangelog.release(changelog_file, new_version=new_version)
+        print("")
+        return (component, version, unreleased)
+
+    if padded_version(latest) > padded_version(version):
+        print(f"\033[95m{component}\033[0m has a new version {version} -> {latest[0]}:")
+        meta = latest[1].pop("metadata")
+        new_version = re.sub(r"[\{\}\[\]]", "", pprint.pformat(latest[1], indent=2))
+        print(new_version)
+        print("")
+        return (component, meta["version"], latest[1])
+    print(f"\033[95m{component}\033[0m has no changes")
+    print("")
+    return (component, version, {})
+
+
+def combine_changelogs(accumulated: dict, current: Tuple[str, str, dict]) -> dict:
+    """Combine changelog for a component with the main changelog"""
+    if current[2]:
+        for heading, changes in current[2].items():
+            prepended = list(map(lambda c: f"{current[0]}: {c}", changes))
+            accumulated["unreleased"].setdefault(heading, []).extend(prepended)
+    accumulated["unreleased"].setdefault("packages", []).append(
+        f"{current[0]}: {current[1]}"
+    )
+    accumulated["unreleased"]["packages"].sort()
+    return accumulated
+
+
+def write_changelog(changes: str) -> str:
+    """Write the changelog and give it a version"""
+    with open(CHANGELOG, "w") as changelog:
+        changelog.write(changes)
+
+    print("\033[95mFirm combined changes\033[0m")
+    unreleased = keepachangelog.to_dict(CHANGELOG, show_unreleased=True).get(
+        "unreleased", {}
+    )
+    unreleased.pop("metadata")
+    print(re.sub(r"[\{\}\[\]]", "", pprint.pformat(unreleased, indent=2)))
+    print("")
+    new_version = get_new_version(
+        keepachangelog.to_dict(CHANGELOG, show_unreleased=True)
+    )
+    keepachangelog.release(CHANGELOG, new_version=new_version)
+    return new_version
+
+
+def release(changelogs: str) -> None:
+    """Here we go"""
+    main_changelog = keepachangelog.to_dict(CHANGELOG, show_unreleased=True)
+    last_packages = list(
+        map(
+            lambda p: p.partition(": ")[::2],
+            find_latest(main_changelog)[1].get("packages", []),
+        )
+    )
+    main_changelog["unreleased"]["packages"] = []
+    check_component_since = partial(check_component, last_packages, changelogs)
+
+    changes = keepachangelog.from_dict(
+        reduce(
+            combine_changelogs,
+            map(check_component_since, os.listdir(changelogs)),
+            main_changelog,
+        )
+    )
+    released = write_changelog(changes)
+    print(f"Updated changelog to release version {released}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command")
+    parser.add_argument("--changelogs")
+    args = parser.parse_args()
+    if args.command == "release":
+        release(args.changelogs)
+    elif args.command == "version":
+        print(find_latest(keepachangelog.to_dict(CHANGELOG))[0])
+    elif args.command == "description":
+        latest_version = find_latest(keepachangelog.to_raw_dict(CHANGELOG))[1]
+        print(latest_version.get("raw"))
+    else:
+        print(f'Unrecognized command "{args.command}"')
+        sys.exit(1)

--- a/libraries/python/firm-types/CHANGELOG.md
+++ b/libraries/python/firm-types/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Python functions to work with the types in the firm protocol.

--- a/libraries/rust/firm-rust/CHANGELOG.md
+++ b/libraries/rust/firm-rust/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Rust API for functions.

--- a/libraries/rust/firm-types/CHANGELOG.md
+++ b/libraries/rust/firm-types/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Rust data types and functions to work with the types in the firm protocol.

--- a/libraries/rust/tonic-middleware/CHANGELOG.md
+++ b/libraries/rust/tonic-middleware/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Http status interceptor

--- a/project.nix
+++ b/project.nix
@@ -3,7 +3,7 @@ let
   sources = import ./nix/sources.nix;
   nedryland = (if nedrylandOverride == null then (import sources.nedryland) else nedrylandOverride);
 in
-nedryland.mkProject {
+nedryland.mkProject rec{
   name = "firm";
   baseExtensions = [
     ./extensions/nedryland/function.nix
@@ -62,5 +62,9 @@ nedryland.mkProject {
     tonicMiddleware = callFile ./libraries/rust/tonic-middleware/tonic-middleware.nix {
       protocols = protocols.withServices.rust; # This brings tonic which we will need. A bit hard to see.
     };
+  };
+
+  extraShells = { callFile }: {
+    release = callFile ./extensions/shells/release.nix { inherit components; };
   };
 }

--- a/services/avery/CHANGELOG.md
+++ b/services/avery/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Authentication service
+- Registry service
+- Execution service
+- Wasi runtime
+- Python runtime

--- a/services/lomax/CHANGELOG.md
+++ b/services/lomax/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Proxy for Avery

--- a/services/quinn/CHANGELOG.md
+++ b/services/quinn/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-07-03
+
+### Added
+- Registry service


### PR DESCRIPTION
Also add a shell for working with releases: `nix-shell -A release`. This
shell can:
- Give version numbers to all unreleased sections in component
  changelogs and combine all new changes to the main changelog.
- Make a tag & github release from the latest version in the changelog.