### PR TITLE
📚 Add changelog entries for installer and events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - protocols-withServices-python, protocols-withServices-rust, protocols-withoutServices-python, protocols-withoutServices-rust: 1.0.0
 - quinn: 1.0.0
 - tonicMiddleware: 1.0.0
+- windowsEvents: 0.1.0
 - windowsInstaller: 0.1.0
 
 ## [1.0.0] - 2021-07-03

--- a/clients/windows-installer/CHANGELOG.md
+++ b/clients/windows-installer/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Make sure pending reboot deletions are correctly formatted
+
 ## [0.1.0] - 2021-09-09
 
 ### Added

--- a/libraries/rust/windows-events/CHANGELOG.md
+++ b/libraries/rust/windows-events/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2021-09-09
+
+### Added
+- crate to register/deregister windows event sources and register events.

--- a/project.nix
+++ b/project.nix
@@ -2,7 +2,7 @@
 let
   sources = import ./nix/sources.nix;
   nedryland = (if nedrylandOverride == null then (import sources.nedryland) else nedrylandOverride);
-  version = "1.0.0";
+  version = "1.1.0";
 in
 nedryland.mkProject rec{
   name = "firm";


### PR DESCRIPTION
WindowsEvents was missing from last version so sneaked it in there. And
bumped the version in the project.