### PR TITLE
✨ Add hosted_domains as a config option

### DIFF
--- a/services/avery/CHANGELOG.md
+++ b/services/avery/CHANGELOG.md
@@ -9,12 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Stop windows service on runtime errors correctly.
 
+## Added
+- Support for multiple hosted domains for authentication.
+
 ## [1.1.0] - 2021-09-09
 
 ### Added
 - Avery can now be run as a user service on windows.
 - As a windows service avery writes to the event log.
 - Avery with runtimes now have windows targets.
+
 ## [1.0.0] - 2021-07-03
 
 ### Added


### PR DESCRIPTION
Support both hosted_domain and hosted_domains as a list, and if anything
in the list matches we consider it accepted. This is because the same
service can be run on a machine where users of multiple domains exists.

When multiple host domains are used the generated url will set
hd to "*".