### PR TITLE
⚡ Add publisher to functions and attachments

### DIFF
--- a/clients/bendini/CHANGELOG.md
+++ b/clients/bendini/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `register` command takes publisher name and email if not provided they will be
+  retrieved from the auth service.
+
 ## [1.0.0] - 2021-07-03
 
 ### Added

--- a/clients/bendini/src/commands/register.rs
+++ b/clients/bendini/src/commands/register.rs
@@ -20,6 +20,8 @@ pub async fn run<T1, T2>(
     mut client: RegistryClient<T1>,
     auth_client: AuthenticationClient<T2>,
     manifest: &Path,
+    publisher_name: &str,
+    publisher_email: &str,
 ) -> Result<(), BendiniError>
 where
     T1: tonic::client::GrpcService<tonic::body::BoxBody> + Clone + Send,
@@ -39,7 +41,7 @@ where
         manifest.to_owned()
     };
 
-    let manifest = FunctionManifest::parse(&manifest_path)?;
+    let manifest = FunctionManifest::parse(&manifest_path, publisher_name, publisher_email)?;
 
     println!("Registering function \"{}\"...", manifest.name());
 

--- a/clients/bendini/src/formatting.rs
+++ b/clients/bendini/src/formatting.rs
@@ -143,14 +143,27 @@ impl Display for Displayer<'_, Function> {
             write!(f, "{}outputs:{}", INDENT, self.outputs.display())?;
 
             if self.metadata.is_empty() {
-                writeln!(f, "{}metadata: n/a", INDENT)
+                writeln!(f, "{}metadata: n/a", INDENT)?;
             } else {
                 writeln!(f, "{}metadata:", INDENT)?;
                 self.metadata
                     .clone()
                     .iter()
-                    .try_for_each(|(x, y)| writeln!(f, "{}{}:{}", INDENT.repeat(2), x, y))
+                    .try_for_each(|(x, y)| writeln!(f, "{}{}:{}", INDENT.repeat(2), x, y))?;
             }
+            writeln!(
+                f,
+                "{}published by: {}<{}>",
+                INDENT,
+                self.publisher
+                    .as_ref()
+                    .map(|p| p.name.as_str())
+                    .unwrap_or("Unknown"),
+                self.publisher
+                    .as_ref()
+                    .map(|p| p.email.as_str())
+                    .unwrap_or("un@known.com")
+            )
         } else {
             Ok(())
         }

--- a/libraries/rust/firm-rust/src/lib.rs
+++ b/libraries/rust/firm-rust/src/lib.rs
@@ -566,7 +566,9 @@ pub mod net {
 mod tests {
     use super::*;
     use firm_types::{
-        functions::{channel::Value as ValueType, Attachment, AttachmentUrl, AuthMethod},
+        functions::{
+            channel::Value as ValueType, Attachment, AttachmentUrl, AuthMethod, Publisher,
+        },
         stream::TryRefFromChannel,
     };
     use mock::MockResultRegistry;
@@ -847,6 +849,11 @@ mod tests {
                 auth_method: AuthMethod::None as i32,
             }),
             created_at: 0,
+            publisher: Some(Publisher {
+                name: String::from("Eggbert"),
+                email: String::from("eggbert@hej.se"),
+            }),
+            signature: None,
         };
         let random_attachment2 = random_attachment.clone();
 

--- a/libraries/rust/firm-types/src/test_helpers.rs
+++ b/libraries/rust/firm-types/src/test_helpers.rs
@@ -32,6 +32,11 @@ macro_rules! attachment {
                 sha256: $sha256.to_owned(),
             }),
             created_at: 0u64,
+            publisher: Some($crate::functions::Publisher {
+                name: String::new(),
+                email: String::new(),
+            }),
+            signature: None,
         }
     }};
 }
@@ -116,11 +121,24 @@ macro_rules! function_data {
             ::std::collections::HashMap::new(),
             ::std::collections::HashMap::new(),
             ::std::collections::HashMap::new(),
+            "Someone",
+            "someone@example.com",
             [$($attach),*],
             {$($key => $value),*})
     }};
 
-    ($name:expr, $version:expr, $runtime_spec:expr, $code:expr, $req_inputs:expr, $opt_inputs:expr, $outputs:expr, [$($attach:expr),*], {$($key:expr => $value:expr),*}) => {{
+    ($name:expr,
+     $version:expr,
+     $runtime_spec:expr,
+     $code:expr,
+     $req_inputs:expr,
+     $opt_inputs:expr,
+     $outputs:expr,
+     $publisher_name:expr,
+     $publisher_email:expr,
+     [$($attach:expr),*],
+     {$($key:expr => $value:expr),*}
+    ) => {{
         let mut metadata = ::std::collections::HashMap::new();
         $(
             metadata.insert(String::from($key), String::from($value));
@@ -135,6 +153,12 @@ macro_rules! function_data {
             optional_inputs: $opt_inputs,
             outputs: $outputs,
             attachment_ids: vec![$(($attach),)*].into_iter().collect(),
+
+            publisher: Some($crate::functions::Publisher {
+                name: String::from($publisher_name),
+                email: String::from($publisher_email),
+            }),
+            signature: None,
         }
     }};
 }
@@ -156,7 +180,7 @@ macro_rules! runtime_spec {
 #[macro_export]
 macro_rules! attachment_data {
     ($name:expr) => {{
-        $crate::attachment_data!($name, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", {})
+        $crate::attachment_data!($name, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
     }};
 
     ($name:expr, $sha256:expr) => {{
@@ -164,6 +188,10 @@ macro_rules! attachment_data {
     }};
 
     ($name:expr, $sha256:expr, {$($key:expr => $value:expr),*}) => {{
+        $crate::attachment_data!($name, $sha256, "Horn Simpa", "hornsimpa@fulfisk.se", {$($key => $value),*})
+    }};
+
+    ($name:expr, $sha256:expr, $publisher_name:expr, $publisher_email:expr, {$($key:expr => $value:expr),*}) => {{
         let mut m = ::std::collections::HashMap::new();
         $(
                 m.insert(String::from($key), String::from($value));
@@ -172,6 +200,11 @@ macro_rules! attachment_data {
             name: String::from($name),
             metadata: m,
             checksums: Some($crate::functions::Checksums { sha256: String::from($sha256) }),
+            publisher: Some($crate::functions::Publisher {
+                name: String::from($publisher_name),
+                email: String::from($publisher_email),
+            }),
+            signature: None,
         }
     }};
 }

--- a/protocols/CHANGELOG.md
+++ b/protocols/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Publisher field to FunctionData, Function, AttachmentData and Attachment.
+- GetIdentity endpoint to auth.
+
 ## [1.0.0] - 2021-07-03
 
 ### Added

--- a/protocols/firm_protocols/auth/auth.proto
+++ b/protocols/firm_protocols/auth/auth.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package firm_protocols.auth;
+import "google/protobuf/empty.proto";
 
 service Authentication {
   rpc AcquireToken (AcquireTokenParameters) returns (Token);
@@ -7,10 +8,16 @@ service Authentication {
   rpc ListRemoteAccessRequests (RemoteAccessListParameters) returns (RemoteAccessRequests);
   rpc ApproveRemoteAccessRequest (RemoteAccessApproval) returns (RemoteAccessRequest);
   rpc GetRemoteAccessRequest (RemoteAccessRequestId) returns (RemoteAccessRequest);
+  rpc GetIdentity (google.protobuf.Empty) returns (Identity);
 }
 
 message AcquireTokenParameters {
   string scope = 1;
+}
+
+message Identity {
+  string name = 1;
+  string email = 2;
 }
 
 message Token {

--- a/protocols/firm_protocols/functions/functions.proto
+++ b/protocols/firm_protocols/functions/functions.proto
@@ -17,6 +17,19 @@ message Function {
   repeated Attachment attachments = 8;
   RuntimeSpec runtime = 9;
   uint64 created_at = 10;
+  Publisher publisher = 11;
+  Signature signature = 12;
+}
+
+
+message Publisher {
+  string name = 1;
+  string email = 2;
+}
+
+
+message Signature {
+  bytes signature = 1;
 }
 
 
@@ -53,6 +66,8 @@ message Attachment {
   map<string, string> metadata = 3;
   Checksums checksums = 4;
   uint64 created_at = 5;
+  Publisher publisher = 6;
+  Signature signature = 7;
 }
 
 

--- a/protocols/firm_protocols/functions/registry.proto
+++ b/protocols/firm_protocols/functions/registry.proto
@@ -63,6 +63,8 @@ message FunctionData {
   AttachmentId code_attachment_id = 7;
   firm_protocols.functions.RuntimeSpec runtime = 8;
   repeated AttachmentId attachment_ids = 9;
+  firm_protocols.functions.Publisher publisher = 10;
+  firm_protocols.functions.Signature signature = 11;
 }
 
 
@@ -77,6 +79,8 @@ message AttachmentData {
   string name = 1;
   map<string, string> metadata = 2;
   firm_protocols.functions.Checksums checksums = 3;
+  firm_protocols.functions.Publisher publisher = 4;
+  firm_protocols.functions.Signature signature = 5;
 }
 
 

--- a/services/avery/CHANGELOG.md
+++ b/services/avery/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Implemented endpoint for GetIdentity
+
 ## [1.2.1] - 2021-10-21
 
 ### Fixed

--- a/services/avery/avery.nix
+++ b/services/avery/avery.nix
@@ -14,6 +14,7 @@
   srcExclude = [
     (path: type: (type == "directory" && baseNameOf path == "runtimes"))
     (path: type: (type == "regular" && baseNameOf path == "avery-with-runtimes.nix"))
+    (path: type: (type == "regular" && baseNameOf path == "CHANGELOG.md"))
   ];
 
   buildInputs = [ types.package tonicMiddleware.package ];

--- a/services/avery/src/auth/oidc.rs
+++ b/services/avery/src/auth/oidc.rs
@@ -388,7 +388,7 @@ impl Oidc {
                     ("client_id", self.oidc_config.client_id.as_str()),
                     ("redirect_uri", redirect_uri.as_str()),
                     ("response_type", "code"),
-                    ("scope", "openid email"),
+                    ("scope", "openid profile email"),
                     ("code_challenge", code_challenge),
                     ("code_challenge_method", "S256"),
                     ("state", &state_string),

--- a/services/avery/src/config.rs
+++ b/services/avery/src/config.rs
@@ -40,7 +40,7 @@ pub enum IdentityProvider {
     Oidc { provider: String },
     Username,
     UsernameSuffix { suffix: String },
-    Override { identity: String },
+    Override { name: String, email: String },
 }
 
 impl Default for IdentityProvider {

--- a/services/avery/src/run.rs
+++ b/services/avery/src/run.rs
@@ -82,6 +82,7 @@ where
         config.auth.identity,
         config.auth.key_store,
         config.auth.allow,
+        crate::system::user_data_path(),
         log.new(o!("service" => "auth")),
     )
     .await?;

--- a/services/avery/src/runtime/filesystem_source.rs
+++ b/services/avery/src/runtime/filesystem_source.rs
@@ -9,8 +9,8 @@ use std::{
 use firm_types::{
     functions::AttachmentUrl,
     functions::AuthMethod,
-    functions::Checksums,
     functions::{Attachment, Stream as ValueStream},
+    functions::{Checksums, Publisher},
     wasi::RuntimeContext,
 };
 use flate2::read::GzDecoder;
@@ -144,6 +144,11 @@ impl Runtime for NestedWasiRuntime {
                     metadata: HashMap::new(),
                     checksums: Some(self.runtime_checksums.clone()),
                     created_at: runtime_timestamp,
+                    publisher: Some(Publisher {
+                        name: String::from("Unknown"),
+                        email: String::from("un@known.org"),
+                    }),
+                    signature: None,
                 }),
                 arguments: HashMap::new(), // files on disk can not have arguments
                 function_dir: runtime_parameters.function_dir,

--- a/services/avery/tests/functions.rs
+++ b/services/avery/tests/functions.rs
@@ -148,6 +148,8 @@ async fn execute() {
             .0,
             std::collections::HashMap::new(),
             channel_specs!({}).0,
+            "Publisher",
+            "publisher@company.com",
             [], // attachments
             {}  // metadata
         )]

--- a/services/quinn/CHANGELOG.md
+++ b/services/quinn/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Quinn stores publisher, with name and email
+
 ## [1.0.0] - 2021-07-03
 
 ### Added

--- a/services/quinn/scripts/postgres.bash
+++ b/services/quinn/scripts/postgres.bash
@@ -9,7 +9,7 @@ get_dirs() {
 start_postgres_server() {
     server_name="$1"
 
-    if [ -z $server_name ]; then
+    if [ -z "$server_name" ]; then
         echo "Please give your server a name"
         return 1
     fi
@@ -17,7 +17,7 @@ start_postgres_server() {
     datadir=$(mktemp -d)
     socket_dir=$(mktemp -d)
 
-    get_dirs $server_name
+    get_dirs "$server_name"
 
     if [ -f "$datadir_file" ]; then
         echo "You already have a server running with name $server_name."
@@ -25,11 +25,11 @@ start_postgres_server() {
         return 1
     fi
 
-    pg_ctl -D $datadir initdb | sed "s/^/  🐘 [postgres] /" || return 1
-    pg_ctl start -D $datadir -o "-k $socket_dir -c listen_addresses=''" || return 1
-    createdb -h $socket_dir functions || return 1
-    echo $datadir >$datadir_file
-    echo $socket_dir >$socket_dir_file
+    pg_ctl -D "$datadir" initdb | sed "s/^/  🐘 [postgres] /" || return 1
+    pg_ctl start -D "$datadir" -o "-k $socket_dir -c listen_addresses=''" || return 1
+    createdb -h "$socket_dir" functions || return 1
+    echo "$datadir" >"$datadir_file"
+    echo "$socket_dir" >"$socket_dir_file"
 
     echo "🎆 Server started! Use this connection string: postgres:///functions?host=$socket_dir&user=$(id -un)"
     echo "To stop it, run stop_postgres_server $server_name"
@@ -39,13 +39,13 @@ start_postgres_server() {
 list_postgres_servers() (
     shopt -s nullglob
     for f in ./.postgres-servers/*.datadir; do
-        echo $(basename ${f/.datadir//})
+        basename "${f/.datadir//}"
     done
 )
 
 stop_all_postgres_servers() {
     for server in $(list_postgres_servers); do
-        stop_postgres_server $server
+        stop_postgres_server "$server"
     done
 }
 
@@ -54,12 +54,12 @@ stop_postgres_server() {
 
     echo "Stopping server $server_name..."
 
-    get_dirs $server_name
-    datadir=$(cat $datadir_file)
+    get_dirs "$server_name"
+    datadir=$(cat "$datadir_file")
 
-    pg_ctl stop -D $datadir | sed "s/^/  🐘 [postgres] /"
-    rm $datadir_file
-    rm $socket_dir_file
+    pg_ctl stop -D "$datadir" | sed "s/^/  🐘 [postgres] /"
+    rm "$datadir_file"
+    rm "$socket_dir_file"
 
     echo "Server $server_name stopped!"
 }
@@ -68,8 +68,8 @@ psql_to_server() {
     server_name="$1"
     shift
 
-    get_dirs $server_name
-    psql -h $(cat $socket_dir_file) functions "$@"
+    get_dirs "$server_name"
+    psql -h "$(cat "$socket_dir_file")" functions "$@"
 }
 
 postgres_tests() (
@@ -79,14 +79,14 @@ postgres_tests() (
     id=$(dd bs=18 count=1 if=/dev/urandom status=none | base64 | tr +/ _.)
     name="cargo-test-$id"
 
-    start_postgres_server $name
-    get_dirs $name
+    start_postgres_server "$name"
+    get_dirs "$name"
 
-    uri="postgres:///functions?host=$(cat $socket_dir_file)&user=$(id -un)"
+    uri="postgres:///functions?host=$(cat "$socket_dir_file")&user=$(id -un)"
     REGISTRY_functions_storage_uri=$uri cargo test --features="postgres-tests" --lib "$@"
     status=$?
 
-    stop_postgres_server $name
+    stop_postgres_server "$name"
     set -e
     exit $status
 )
@@ -94,7 +94,7 @@ postgres_tests() (
 start_postgres_server_with_data() {
     start_postgres_server "$1"
     get_dirs "$1"
-    uri="postgres:///functions?host=$(cat $socket_dir_file)&user=$(id -un)"
+    uri="postgres:///functions?host=$(cat "$socket_dir_file")&user=$(id -un)"
     REGISTRY_functions_storage_uri=$uri cargo run --bin seed -- "$@"
 }
 

--- a/services/quinn/src/bin/seed.rs
+++ b/services/quinn/src/bin/seed.rs
@@ -33,6 +33,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             code: None,
             attachments: vec![],
             created_at: 4,
+            publisher: storage::Publisher {
+                name: String::from("Johansen Rackstr"),
+                email: String::from("l1333@rackstr.no"),
+            },
+            signature: None,
         })
         .await?;
     let attachment_id = storage
@@ -42,6 +47,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             checksums: storage::Checksums {
                 sha256: "🚢🛥️⛴️🚤".to_owned(),
             },
+            publisher: storage::Publisher {
+                name: "Skrubb Skädda".to_owned(),
+                email: "skrubb.skadda@fisk.se".to_owned(),
+            },
+            signature: None,
         })
         .await?
         .id;
@@ -61,6 +71,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             code: None,
             attachments: vec![attachment_id],
             created_at: 3,
+            publisher: storage::Publisher {
+                name: String::from("Budas"),
+                email: String::from("budas@budarsson.com"),
+            },
+            signature: None,
         })
         .await?;
     storage
@@ -79,6 +94,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             code: None,
             attachments: vec![],
             created_at: 2,
+            publisher: storage::Publisher {
+                name: String::from("sven-benny"),
+                email: String::from("sven-benny@svenbennysson.com"),
+            },
+            signature: None,
         })
         .await?;
     storage
@@ -97,6 +117,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             code: None,
             attachments: vec![],
             created_at: 1,
+            publisher: storage::Publisher {
+                name: String::from("Lasse-gurra Aktersnurra"),
+                email: String::from("lassegurra@aktersnurra.se"),
+            },
+            signature: None,
         })
         .await?;
     Ok(())

--- a/services/quinn/src/storage.rs
+++ b/services/quinn/src/storage.rs
@@ -48,6 +48,14 @@ pub struct Function {
     pub code: Option<Uuid>,
     pub attachments: Vec<Uuid>,
     pub created_at: u64,
+    pub publisher: Publisher,
+    pub signature: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Publisher {
+    pub name: String,
+    pub email: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -80,6 +88,8 @@ pub struct FunctionAttachmentData {
     pub name: String,
     pub metadata: HashMap<String, String>,
     pub checksums: Checksums,
+    pub publisher: Publisher,
+    pub signature: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default)]

--- a/services/quinn/src/storage/gcs.rs
+++ b/services/quinn/src/storage/gcs.rs
@@ -52,7 +52,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::storage::{Checksums, FunctionAttachmentData};
+    use crate::storage::{Checksums, FunctionAttachmentData, Publisher};
     use std::collections::HashMap;
 
     #[test]
@@ -74,6 +74,11 @@ mod tests {
                 checksums: Checksums {
                     sha256: "nej".to_owned(),
                 },
+                publisher: Publisher {
+                    name: "Knagg Rocka".to_owned(),
+                    email: "knagg@matt-fisk.se".to_owned(),
+                },
+                signature: None,
             },
             created_at: 0,
         });

--- a/services/quinn/src/storage/https.rs
+++ b/services/quinn/src/storage/https.rs
@@ -50,7 +50,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::storage::{Checksums, FunctionAttachmentData};
+    use crate::storage::{Checksums, FunctionAttachmentData, Publisher};
     use std::collections::HashMap;
 
     #[test]
@@ -69,6 +69,11 @@ mod tests {
                 checksums: Checksums {
                     sha256: "nej".to_owned(),
                 },
+                publisher: Publisher {
+                    name: "Sju Rygg".to_owned(),
+                    email: "sju@fetfisk.se".to_owned(),
+                },
+                signature: None,
             },
             created_at: 1337,
         });
@@ -91,6 +96,11 @@ mod tests {
                 checksums: Checksums {
                     sha256: "nej".to_owned(),
                 },
+                publisher: Publisher {
+                    name: "Horn Simpa".to_owned(),
+                    email: "hornsimpa@fulfisk.se".to_owned(),
+                },
+                signature: None,
             },
             created_at: 1337,
         });


### PR DESCRIPTION
Bendini has two new optional arguments `--publisher-name` &
`--publisher-email` when registering to set name and email of the
publisher. They are stored and shown in listings.