### PR TITLE
[CORE-9] 🔨 Make auth init side-effect-free

### DIFF
--- a/services/avery/src/auth/oidc.rs
+++ b/services/avery/src/auth/oidc.rs
@@ -293,7 +293,7 @@ struct Claims {
     extra: HashMap<String, serde_json::Value>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Oidc {
     oidc_config: crate::config::OidcProvider,
     logger: Logger,

--- a/services/avery/src/run.rs
+++ b/services/avery/src/run.rs
@@ -82,7 +82,9 @@ where
         config.auth.identity,
         config.auth.key_store,
         config.auth.allow,
-        crate::system::user_data_path(),
+        crate::system::user_data_path().ok_or_else(|| {
+            String::from("Failed to determine user data path for storing generated keys")
+        })?,
         log.new(o!("service" => "auth")),
     )
     .await?;

--- a/services/avery/tests/auth.rs
+++ b/services/avery/tests/auth.rs
@@ -22,6 +22,7 @@ const PUBLIC_KEY: &str = r#"-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhaadwO6uGY7Z4p/aQ6EjM6aSHM0vjuVJHijOlq/B4IRyP5qBnVmJGxqlD53diU5s/GG6RqF89insKUUOJ6OHMQ==
 -----END PUBLIC KEY-----"#;
 
+#[derive(Debug)]
 struct FakeKeyStore {
     key_data: Vec<u8>,
 }
@@ -517,7 +518,7 @@ async fn test_get_identity() {
         },
         ConfigKeyStore::None,
         AllowConfig::default(),
-        Some(tempdir().unwrap().into_path()),
+        tempdir().unwrap().into_path(),
         null_logger!(),
     )
     .await;
@@ -533,11 +534,11 @@ async fn test_get_identity() {
         }
     );
 
-    // Test empty identity
+    // Test default (should use the default identity provider "user")
     let service = auth_service!();
     let identity = service.get_identity(tonic::Request::new(())).await;
     assert!(
-        identity.is_err(),
-        "Expected empty identity from default auth service"
+        identity.is_ok(),
+        "Expected default identity from default auth service"
     )
 }


### PR DESCRIPTION
Previously, generation of keys, identity retrieval and upload of public
keys was done on startup of Avery. Now instead, this is done as late as
possible, making initialization of the auth service free of any side
effects.

Due to how the key store is dependent on the token store for acquiring
its credentials, there is some hoop-jumping necessary to be able to have
the correct lock scopes.