### PR TITLE
🐛 Update cargo toml versions from prev release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Release shell reports success.
+
 ### Fixed
 - The release shell's makeRelease now uses the provided github token correctly.
+- Avery, Lomax, Quinn and Bendini having wrong versions in Cargo.toml.
+- Fixed 2.0.0 changelog.
 
 ## [2.0.0] - 2021-12-16
 ### Packages
@@ -59,12 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - protocols: Name filter is now just a string instead of a type
 - avery: Public keys are now uploaded together with a key id making it possible to have multiple keys per users.
 - avery: Startup of Avery is now side-effect free. This means that no keys are generated and no
-- avery: login will be required.
+         login will be required.
 - avery: Login is no longer automatic. Any request that would have required a login will now
-- avery: return a gRPC `unauthenticated`. An interactive client can then choose to call `login`
-- avery: to start an interactive login process. This process is carried out with the help of a
-- avery: stream of login commands which instructs the client which actions to take during the
-- avery: login process.
+         return a gRPC `unauthenticated`. An interactive client can then choose to call `login`
+         to start an interactive login process. This process is carried out with the help of a
+         stream of login commands which instructs the client which actions to take during the
+         login process.
 
 ## [1.2.1] - 2021-10-21
 ### Packages

--- a/clients/bendini/Cargo.toml
+++ b/clients/bendini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bendini"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["GBK Pipeline Team <pipeline@goodbyekansas.com>"]
 edition = "2021"
 

--- a/extensions/shells/release/shell-scripts.bash
+++ b/extensions/shells/release/shell-scripts.bash
@@ -17,8 +17,11 @@ updateChangelogs() {
     echo "The main changelog will also get a ###Packages header with the version of each component."
   else
     python "$CHANGELOG_SCRIPT" release --changelogs "$allChangelogs"
+    echo "Remember to update Cargo.toml with correct versions!"
   fi
 }
+
+# TODO: Automate to update Cargo.toml files with correct versions.
 
 makeRelease() {
   (
@@ -44,6 +47,7 @@ makeRelease() {
     fi
     export GITHUB_TOKEN
     github-release release --tag "$version" --description "$description"
+    echo "Release \"$version\" done! 📦"
   )
 }
 

--- a/project.nix
+++ b/project.nix
@@ -5,7 +5,7 @@ let
 in
 nedryland.mkProject rec {
   name = "firm";
-  version = "1.2.1";
+  version = "2.0.0";
   baseExtensions = [
     ./extensions/nedryland/function.nix
     ./extensions/nedryland/runtime.nix

--- a/services/avery/Cargo.lock
+++ b/services/avery/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "avery"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/services/avery/Cargo.toml
+++ b/services/avery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avery"
-version = "1.2.1"
+version = "2.0.0"
 authors = ["GBK Pipeline Team <pipeline@goodbyekansas.com>"]
 edition = "2021"
 

--- a/services/lomax/Cargo.lock
+++ b/services/lomax/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "lomax"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "chrono",

--- a/services/lomax/Cargo.toml
+++ b/services/lomax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lomax"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["GBK Pipeline Team <pipeline@goodbyekansas.com>"]
 edition = "2021"
 

--- a/services/quinn/Cargo.toml
+++ b/services/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quinn"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["GBK Pipeline Team <pipeline@goodbyekansas.com>"]
 edition = "2021"
 default-run = "quinn"


### PR DESCRIPTION
- We earlier made a release and forgot to update all the Cargo.toml
files (They previously had the correct version considering the changes
and the release).
- Add more prints to release shell.
- Fixed some minor mistakes in the changelog for the 2.0.0 release.