### PR TITLE
🐛 Fix wrong kid for generated keys

### DIFF
--- a/services/avery/CHANGELOG.md
+++ b/services/avery/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The generated keys used a hash of the DER format but when the key is saved and later
+  read from disk it uses the PEM format, causing a hash mismatch. This changes the hash to
+  always use the PEM variant.
+
+
 ## [2.0.0] - 2021-12-16
 
 ### Changed

--- a/services/avery/src/auth.rs
+++ b/services/avery/src/auth.rs
@@ -977,7 +977,12 @@ impl Authentication for AuthService {
             self.key_store
                 .set(&keyid, &key_content)
                 .await
-                .map_err(|e| tonic::Status::internal(e.to_string()))?
+                .map_err(|e| tonic::Status::internal(e.to_string()))?;
+
+            debug!(
+                self.logger,
+                "Done uploading generated key with id {}", keyid
+            );
         }
 
         Ok(tonic::Response::new(proto_token))


### PR DESCRIPTION
The generated keys used a hash of the DER format but when the key is
saved and later read from disk it uses the PEM format, causing a hash
mismatch. This changes the hash to always use the PEM variant.