### PR TITLE
🐛 Fix installer removing too many files

### DIFF
--- a/clients/windows-installer/CHANGELOG.md
+++ b/clients/windows-installer/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Installer removing files it did not own during uninstall.
+  The installer now only work on files it extracted itself. If you
+  manually add extra files in for example the install directory
+  it will ignore those during uninstall.
+
+- Issue where installer could not mark files for deletion.
+
 ## [0.1.1] - 2021-09-15
 
 ### Fixed

--- a/clients/windows-installer/src/service.rs
+++ b/clients/windows-installer/src/service.rs
@@ -1,4 +1,9 @@
-use std::{ffi::OsString, fmt::Display, os::windows::prelude::{OsStrExt, OsStringExt}, ptr, u32};
+use std::{
+    ffi::OsString,
+    fmt::Display,
+    os::windows::prelude::{OsStrExt, OsStringExt},
+    ptr, u32,
+};
 
 use thiserror::Error;
 use winapi::{
@@ -103,7 +108,7 @@ impl Drop for WinHandle {
 impl Display for WinHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
-    } 
+    }
 }
 
 struct UserServiceEnumerator<'a> {
@@ -151,7 +156,7 @@ impl UserServiceEnumerator<'_> {
                 .filter_map(|service| {
                     get_service_handle(
                         &parse_str_ptr(service.lpServiceName).to_string_lossy(),
-                        &manager_handle,
+                        manager_handle,
                     )
                     .ok()
                 })


### PR DESCRIPTION
The installer now only works with files it has extracted.
If you for example manually add files to the install directory
those will be ingored during uninstall.

Fixed a bug where a registry key didn't exist which resulted
in the installer being unanble to mark files for deletion.

FIXES: #286, #284