### PR TITLE
✨ Support hostname expansion in alt names

### DIFF
--- a/services/lomax/CHANGELOG.md
+++ b/services/lomax/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for expansion of `{hostname}` to the real hostname in the
+  `certificate_alt_names` config setting.
+
 ## [2.0.0] - 2021-12-16
 
 ### Added

--- a/services/lomax/Cargo.lock
+++ b/services/lomax/Cargo.lock
@@ -293,6 +293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +692,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "structopt",
+ "tempfile",
  "tokio",
  "tokio-rustls",
  "tower",
@@ -1380,13 +1399,13 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/services/lomax/Cargo.toml
+++ b/services/lomax/Cargo.toml
@@ -39,4 +39,5 @@ winlog = "0.2.6"
 # for winlog
 log = "0.4.14"
 
-
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/services/lomax/src/config.rs
+++ b/services/lomax/src/config.rs
@@ -31,7 +31,7 @@ struct MaybeCertificateLocations {
     pub certificate_key_location: Option<PathBuf>,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Default)]
 #[serde(try_from = "MaybeCertificateLocations")]
 pub struct CertificateLocations {
     pub cert: PathBuf,
@@ -55,7 +55,7 @@ impl TryFrom<MaybeCertificateLocations> for CertificateLocations {
     }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Default)]
 pub struct Config {
     #[serde(default = "default_port")]
     pub port: u16,


### PR DESCRIPTION
Support expansion of `{hostname}` to the real hostname in the
`certificate_alt_names` config setting. To properly support this, a
version of the certificate was also added that is based on a djb2 hash
of config content that impacts the generation of the certificate. If
this hash changes, the certificate is regenerated even though it exists.