### PR TITLE
🎨 Firm installer differentiate log and term

### DIFF
--- a/clients/firm-windows-installer/Cargo.lock
+++ b/clients/firm-windows-installer/Cargo.lock
@@ -71,6 +71,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "field-offset"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +167,7 @@ dependencies = [
 name = "firm-windows-installer"
 version = "0.1.2"
 dependencies = [
+ "console",
  "flate2",
  "slog",
  "slog-async",
@@ -470,6 +492,16 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
  "winapi",
 ]
 

--- a/clients/firm-windows-installer/Cargo.toml
+++ b/clients/firm-windows-installer/Cargo.toml
@@ -11,5 +11,6 @@ thiserror = "1"
 slog = { version="2", features=["release_max_level_debug"] }
 slog-term = "2"
 slog-async = "2"
+console = "0.15"
 
 windows-install = { version = "0.1.0", registry = "nix" }


### PR DESCRIPTION
- The log always get everything
- Add console::Term for writing to the terminal

The terminal and log sometimes report similar things but it's more by
mistake. They are separate now. You can control and still get log
messages to the terminal by setting log level. By default only
critical will be printed.